### PR TITLE
Updated must gather base image to version 4.15.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -104,6 +104,9 @@ externalImages:
   - name: "kube-rbac-proxy"
     image: registry.redhat.io/openshift4/ose-kube-rbac-proxy
     version: v4.15
+  - name: "must-gather"
+    image: registry.redhat.io/openshift4/ose-must-gather
+    version: v4.15
 
 # Konflux images are images that are built from the source in this repository
 konfluxImages:

--- a/config.yaml
+++ b/config.yaml
@@ -104,9 +104,6 @@ externalImages:
   - name: "kube-rbac-proxy"
     image: registry.redhat.io/openshift4/ose-kube-rbac-proxy
     version: v4.15
-  - name: "must-gather"
-    image: registry.redhat.io/openshift4/ose-must-gather
-    version: v4.15
 
 # Konflux images are images that are built from the source in this repository
 konfluxImages:

--- a/containers/must-gather/Dockerfile
+++ b/containers/must-gather/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 # ------------------------------------------------------------------------
-FROM registry.redhat.io/openshift4/ose-must-gather:v4.13.0
+FROM registry.redhat.io/openshift4/ose-must-gather:v4.15.0
 
 LABEL \
     name="openshift-gitops-1/must-gather-rhel8" \


### PR DESCRIPTION
**What does this PR do / why we need it**:
Update must gather base image to version 4.15

**Which issue(s) this PR fixes**:
Fixes: https://issues.redhat.com/browse/GITOPS-7188

depends on https://github.com/redhat-developer/gitops-must-gather/pull/32
