### PR TITLE
chore: add argocd-agent configs for gitops-operator

### DIFF
--- a/containers/gitops-operator-bundle/patch-bundle.py
+++ b/containers/gitops-operator-bundle/patch-bundle.py
@@ -107,6 +107,7 @@ relatedImages = [
     {'name': 'argocd_extension_image', 'image': images['argocd-extenstions']},
     {'name': 'argo_rollouts_image', 'image': images['argo-rollouts']},
     {'name': 'must_gather_image', 'image': images['must-gather']},
+    {'name': 'argocd_principal_image', 'image': images['argocd-agent']},
 ]
 
 new_env = [
@@ -135,6 +136,7 @@ new_env = [
     {'name': 'ARGO_ROLLOUTS_IMAGE', 'value': images['argo-rollouts']},
     {'name': 'RELATED_IMAGE_MUST_GATHER_IMAGE', 'value': images['must-gather']},
     {'name': 'RELATED_IMAGE_KUBE_RBAC_PROXY_IMAGE', 'value': images['kube-rbac-proxy']},
+    {'name': 'ARGOCD_PRINCIPAL_IMAGE', 'value': images['argocd-agent']},
 ]
 
 # --- OLM fields ---


### PR DESCRIPTION
This PR is to add Argo CD agent image configurations for GitOps-operator.