### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for gitops-1-17

### DIFF
--- a/containers/gitops/Dockerfile
+++ b/containers/gitops/Dockerfile
@@ -19,6 +19,7 @@ LABEL \
     name="openshift-gitops-1/gitops-rhel8" \
     License="Apache 2.0" \
     com.redhat.component="openshift-gitops-container" \
+    cpe="cpe:/a:redhat:openshift_gitops:1.17::el8" \
     com.redhat.delivery.appregistry="false" \
     upstream-vcs-type="git" \
     summary="Red Hat OpenShift GitOps Backend Service" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
