### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for gitops-operator-1-17

### DIFF
--- a/containers/gitops-operator/Dockerfile
+++ b/containers/gitops-operator/Dockerfile
@@ -52,6 +52,7 @@ LABEL \
     summary="Openshift GitOps Operator Dockerfile Template" \
     description="Red Hat OpenShift GitOps Operator" \
     maintainer="William Tam <wtam@redhat.com>"  \
+    cpe="cpe:/a:redhat:openshift_gitops:1.17::el8" \
     com.redhat.component="openshift-gitops-operator-container" \
     io.openshift.tags="openshift,gitops-operator" \
     io.k8s.display-name="Red Hat OpenShift GitOps Operator" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
