### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for gitops-operator-bundle-1-17

### DIFF
--- a/containers/gitops-operator-bundle/Dockerfile
+++ b/containers/gitops-operator-bundle/Dockerfile
@@ -21,7 +21,8 @@ COPY containers/gitops-operator-bundle/bundle/metadata /metadata/
 COPY containers/gitops-operator-bundle/bundle/tests/scorecard /tests/scorecard/
 
 LABEL \
-    name="openshift-gitops-1/gitops-rhel8-operator" \
+    name="openshift-gitops-1/gitops-operator-bundle" \
+    cpe="cpe:/a:redhat:openshift_gitops:1.17::el8" \
     url="" \
     vendor="Red Hat, Inc." \
     com.redhat.component="openshift-gitops-operator-bundle-container" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
