### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for dex-1-17

### DIFF
--- a/containers/dex/Dockerfile
+++ b/containers/dex/Dockerfile
@@ -53,6 +53,7 @@ LABEL \
     name="openshift-gitops-1/dex-rhel8" \
     License="Apache 2.0" \
     com.redhat.component="openshift-gitops-dex-container" \
+    cpe="cpe:/a:redhat:openshift_gitops:1.17::el8" \
     com.redhat.delivery.appregistry="false" \
     summary="Red Hat OpenShift GitOps Dex" \
     downstream-vcs-type="git" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
