### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for console-plugin-1-17

### DIFF
--- a/containers/console-plugin/Dockerfile
+++ b/containers/console-plugin/Dockerfile
@@ -46,7 +46,8 @@ COPY --from=builder /workspace/gitops-console-plugin/dist /var/www/html/plugin
 CMD run-httpd
     
 LABEL \
-    name="openshift-gitops-1/gitops-console-plugin-rhel8" \
+    name="openshift-gitops-1/console-plugin-rhel8" \
+    cpe="cpe:/a:redhat:openshift_gitops:1.17::el8" \
     License="Apache 2.0" \
     com.redhat.component="openshift-gitops-console-plugin-container" \
     com.redhat.delivery.appregistry="false" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
