### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for argocd-agent-1-17

### DIFF
--- a/containers/argocd-agent/Dockerfile
+++ b/containers/argocd-agent/Dockerfile
@@ -46,4 +46,5 @@ LABEL \
     io.k8s.display-name="openshift-gitops-argo-agent" \
     io.k8s.description="Red Hat OpenShift GitOps Argo CD Agent" \
     maintainer="William Tam <wtam@redhat.com>" \
+    cpe="cpe:/a:redhat:openshift_gitops:1.17::el8" \
     description="Red Hat OpenShift GitOps Argo CD Agent"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
