### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for gitops-1-16

### DIFF
--- a/containers/gitops/Dockerfile
+++ b/containers/gitops/Dockerfile
@@ -20,6 +20,7 @@ LABEL \
     License="Apache 2.0" \
     com.redhat.component="openshift-gitops-container" \
     com.redhat.delivery.appregistry="false" \
+    cpe="cpe:/a:redhat:openshift_gitops:1.16::el8" \
     upstream-vcs-type="git" \
     summary="Red Hat OpenShift GitOps Backend Service" \
     io.openshift.expose-services="" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
