### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for argo-rollouts-1-16

### DIFF
--- a/containers/argo-rollouts/Dockerfile
+++ b/containers/argo-rollouts/Dockerfile
@@ -119,6 +119,7 @@ LABEL \
     io.k8s.display-name="openshift-gitops-argo-rollouts" \
     io.k8s.description="Red Hat Openshift GitOps Argo Rollouts" \
     maintainer="William Tam <wtam@redhat.com>" \
+    cpe="cpe:/a:redhat:openshift_gitops:1.16::el8" \
     description="Red Hat Openshift GitOps Argo Rollouts"
 
 ENTRYPOINT [ "/usr/local/bin/rollouts-controller"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
