### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for argocd-extensions-1-16

### DIFF
--- a/containers/argocd-extensions/Dockerfile
+++ b/containers/argocd-extensions/Dockerfile
@@ -65,4 +65,5 @@ LABEL \
     io.k8s.display-name="Red Hat OpenShift GitOps ArgoCD Extensions" \
     maintainer="William Tam <wtam@redhat.com>" \
     description="Red Hat OpenShift GitOps ArgoCD Extensions" \
-    io.k8s.description="Red Hat OpenShift GitOps ArgoCD Extensions"
+    io.k8s.description="Red Hat OpenShift GitOps ArgoCD Extensions" \
+    cpe="cpe:/a:redhat:openshift_gitops:1.16::el8"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
