### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for must-gather-1-15

### DIFF
--- a/containers/must-gather/Dockerfile
+++ b/containers/must-gather/Dockerfile
@@ -19,7 +19,8 @@ LABEL \
     name="openshift-gitops-1/must-gather-rhel8" \
     License="Apache 2.0" \
     com.redhat.component="openshift-gitops-must-gather-container" \
-    com.redhat.delivery.appregistry="false" \ 
+    com.redhat.delivery.appregistry="false" \
+    cpe="cpe:/a:redhat:openshift_gitops:1.15::el8" \
     upstream-vcs-type="git" \
     summary="OpenShift GitOps Must Gather" \
     description="Red Hat OpenShift GitOps Must Gather" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
