### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for gitops-operator-1-15

### DIFF
--- a/containers/gitops-operator/Dockerfile
+++ b/containers/gitops-operator/Dockerfile
@@ -44,12 +44,13 @@ ENTRYPOINT [ "/usr/local/bin/manager" ]
 LABEL \
     name="openshift-gitops-1/gitops-rhel8-operator" \
     License="Apache 2.0" \
+    cpe="cpe:/a:redhat:openshift_gitops:1.15::el8" \
     com.redhat.component="openshift-gitops-operator-container" \
     com.redhat.delivery.appregistry="false" \
     upstream-vcs-type="git" \
     summary="Openshift GitOps Operator Dockerfile Template" \
     description="Red Hat OpenShift GitOps Operator" \
-    maintainer="William Tam <wtam@redhat.com>"  \
+    maintainer="William Tam <wtam@redhat.com>" \
     com.redhat.component="openshift-gitops-operator-container" \
     io.openshift.tags="openshift,gitops-operator" \
     io.k8s.display-name="Red Hat OpenShift GitOps Operator" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
