### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for dex-1-15

### DIFF
--- a/containers/dex/Dockerfile
+++ b/containers/dex/Dockerfile
@@ -62,4 +62,5 @@ LABEL \
     io.k8s.display-name="Red Hat OpenShift GitOps Dex" \
     io.k8s.description="Red Hat OpenShift GitOps Dex" \
     maintainer="William Tam <wtam@redhat.com>" \
-    description="Red Hat OpenShift GitOps Dex"
+    description="Red Hat OpenShift GitOps Dex" \
+    cpe="cpe:/a:redhat:openshift_gitops:1.15::el8"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
