### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for argo-rollouts-1-15

### DIFF
--- a/containers/argo-rollouts/Dockerfile
+++ b/containers/argo-rollouts/Dockerfile
@@ -107,6 +107,7 @@ LABEL \
     License="Apache 2.0" \
     com.redhat.component="openshift-gitops-argo-rollouts-container" \
     com.redhat.delivery.appregistry="false" \
+    cpe="cpe:/a:redhat:openshift_gitops:1.15::el8" \
     upstream-vcs-type="git" \
     summary="Red Hat Openshift GitOps Argo Rollouts" \
     io.openshift.expose-services="" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
