### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for argocd-extensions-1-15

### DIFF
--- a/containers/argocd-extensions/Dockerfile
+++ b/containers/argocd-extensions/Dockerfile
@@ -59,6 +59,7 @@ LABEL \
     License="Apache 2.0" \
     com.redhat.component="openshift-gitops-argocd-extensions-container" \
     com.redhat.delivery.appregistry="false" \
+    cpe="cpe:/a:redhat:openshift_gitops:1.15::el8" \
     summary="Red Hat OpenShift GitOps Argocd Extensions" \
     io.openshift.expose-services="" \
     io.openshift.tags="openshift,gitops,extensions,argocd" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
