### PR TITLE
build(deps): Bump argocd-agent version

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -84,8 +84,8 @@ sources:
     commit: 09102635500867f4119ae63008bf1fe1ae7328b5
   - path: sources/argocd-agent
     url: https://github.com/argoproj-labs/argocd-agent.git
-    ref: v0.5.4
-    commit: 1414e5e4dbc99a45ff73d99a76d4e04bda732226
+    ref: release-0.5
+    commit: 65bdacbc827ef162938ea4a40f578905cd7d6893
   - path: sources/argocd-image-updater
     url: https://github.com/argoproj-labs/argocd-image-updater.git
     ref: v1.0.3

--- a/config.yaml
+++ b/config.yaml
@@ -84,8 +84,8 @@ sources:
     commit: 09102635500867f4119ae63008bf1fe1ae7328b5
   - path: sources/argocd-agent
     url: https://github.com/argoproj-labs/argocd-agent.git
-    ref: release-0.5
-    commit: 65bdacbc827ef162938ea4a40f578905cd7d6893
+    ref: v0.5.5
+    commit: d8c7f9287090d963ba8b1ca5678079c7dc77a342
   - path: sources/argocd-image-updater
     url: https://github.com/argoproj-labs/argocd-image-updater.git
     ref: v1.0.3


### PR DESCRIPTION
This PR is to upgrade argocd-agent version to the commit having fix for [CVE-2026-33186](https://access.redhat.com/security/cve/cve-2026-33186).