### PR TITLE
chore(bundle): latest bundle updates for v1.20.2-2

### DIFF
--- a/containers/gitops-operator-bundle/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/containers/gitops-operator-bundle/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -179,7 +179,7 @@ metadata:
       ]
     capabilities: Deep Insights
     console.openshift.io/plugins: '["gitops-plugin"]'
-    containerImage: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:7c4624a79f3d788b5c790b7792cfc8ec58a73914d246a7d231285e758f2ac3e5
+    containerImage: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:446d622629b0f9cf506eb040497a13166e9eea2ac1950d6d19db7675d616f53f
     createdAt: "2026-03-04T06:59:29Z"
     description: Enables teams to adopt GitOps principles for managing cluster configurations and application delivery across hybrid multi-cluster Kubernetes environments.
     features.operators.openshift.io/disconnected: "true"
@@ -198,7 +198,7 @@ metadata:
     support: Red Hat
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/internal-objects: '["gitopsservices.pipelines.openshift.io"]'
-    operators.openshift.io/must-gather-image: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:24e9a0cd96c392f28c070c71de34c6704a51dc98b316f1dd8b6fe4ba96ed2c61
+    operators.openshift.io/must-gather-image: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:df046b3d40bb5f011f9994f7611feaf581bad57902a5ac4ce93952e6026732e4
     features.operators.openshift.io/cnf: 'false'
     features.operators.openshift.io/cni: 'false'
     features.operators.openshift.io/csi: 'false'
@@ -843,19 +843,19 @@ spec:
                       - name: ENABLE_CONVERSION_WEBHOOK
                         value: 'true'
                       - name: RELATED_IMAGE_ARGOCD_DEX_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:a23ac8b59a2c3277c6f0a73c26f45c2058b21525829677fa9996e14cd748a4e0
+                        value: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:db761c36083601bce4191547e51923197c2940362758dc463563c2fab01fb0bd
                       - name: ARGOCD_DEX_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:a23ac8b59a2c3277c6f0a73c26f45c2058b21525829677fa9996e14cd748a4e0
+                        value: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:db761c36083601bce4191547e51923197c2940362758dc463563c2fab01fb0bd
                       - name: RELATED_IMAGE_BACKEND_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:f45a9aebd083a25750301a711758626e23f87a3645982112b3e03293147d8236
+                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:6f2d2c3ac261e6802d919127b23ab1310b99009b41dd95c595bf6a5d1b3569ce
                       - name: BACKEND_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:f45a9aebd083a25750301a711758626e23f87a3645982112b3e03293147d8236
+                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:6f2d2c3ac261e6802d919127b23ab1310b99009b41dd95c595bf6a5d1b3569ce
                       - name: RELATED_IMAGE_ARGOCD_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:f68c2895439e7c1f780a09aedf128baf9c129da38bce894bf2bb42abf5d6c451
+                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:88189118c6b213fb533b0aaaa907baab156d11903f0c62caae76505326231d0d
                       - name: ARGOCD_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:f68c2895439e7c1f780a09aedf128baf9c129da38bce894bf2bb42abf5d6c451
+                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:88189118c6b213fb533b0aaaa907baab156d11903f0c62caae76505326231d0d
                       - name: ARGOCD_REPOSERVER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:f68c2895439e7c1f780a09aedf128baf9c129da38bce894bf2bb42abf5d6c451
+                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:88189118c6b213fb533b0aaaa907baab156d11903f0c62caae76505326231d0d
                       - name: RELATED_IMAGE_ARGOCD_REDIS_IMAGE
                         value: registry.redhat.io/rhel9/redis-7@sha256:3d31c0cfaf4219f5bd1c52882b603215d1cb4aaef5b8d1a128d0174e090f96f3
                       - name: ARGOCD_REDIS_IMAGE
@@ -867,34 +867,34 @@ spec:
                       - name: ARGOCD_REDIS_HA_PROXY_IMAGE
                         value: registry.redhat.io/openshift4/ose-haproxy-router@sha256:31d16a1533730e682b55b2b870f4175f3eef8030667f1713a593733b9da8cd53
                       - name: RELATED_IMAGE_GITOPS_CONSOLE_PLUGIN_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:f39e1668c1981190529ce9264c4bb2be87c627985e580dbf64f0a76042b6bfba
+                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:eefdfc78f1a89911b151e469a89334e31fb6ebcc8767b8e27cf38a798a21e3a8
                       - name: GITOPS_CONSOLE_PLUGIN_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:f39e1668c1981190529ce9264c4bb2be87c627985e580dbf64f0a76042b6bfba
+                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:eefdfc78f1a89911b151e469a89334e31fb6ebcc8767b8e27cf38a798a21e3a8
                       - name: RELATED_IMAGE_ARGOCD_EXTENSION_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:6748e135958942d055cdfd1d2f20aee278b3b21e9937f6431bbd860948f6bc38
+                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:741b99d79c2d7b482bc3429287dd3ee9476b73754b0120fb63ca758c1322b5f6
                       - name: ARGOCD_EXTENSION_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:6748e135958942d055cdfd1d2f20aee278b3b21e9937f6431bbd860948f6bc38
+                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:741b99d79c2d7b482bc3429287dd3ee9476b73754b0120fb63ca758c1322b5f6
                       - name: RELATED_IMAGE_ARGO_ROLLOUTS_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:41fdac243aa6c9af6f7ee6610ec6377de7316a9a769f4ddea7ec3016f0fcfcdd
+                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:0aafa78de280080c6f75aba32465ccd4038f53752240433a3dc1ebf70b976c75
                       - name: ARGO_ROLLOUTS_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:41fdac243aa6c9af6f7ee6610ec6377de7316a9a769f4ddea7ec3016f0fcfcdd
+                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:0aafa78de280080c6f75aba32465ccd4038f53752240433a3dc1ebf70b976c75
                       - name: RELATED_IMAGE_MUST_GATHER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:24e9a0cd96c392f28c070c71de34c6704a51dc98b316f1dd8b6fe4ba96ed2c61
+                        value: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:df046b3d40bb5f011f9994f7611feaf581bad57902a5ac4ce93952e6026732e4
                       - name: RELATED_IMAGE_KUBE_RBAC_PROXY_IMAGE
                         value: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:e6bfbe1e3a33d6f146ca70c040d0232ab254f98847efd1b2a382685c331e53a2
                       - name: ARGOCD_PRINCIPAL_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:cdb7b8e196f7b40cfd29643a85a9fd79d9800310114ea085db5a82f3546e8591
+                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:65d2f8411d0efc285b2e6c55c3e94ef097b217359ef0ce1abe739122399ac5b7
                       - name: RELATED_IMAGE_ARGOCD_PRINCIPAL_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:cdb7b8e196f7b40cfd29643a85a9fd79d9800310114ea085db5a82f3546e8591
+                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:65d2f8411d0efc285b2e6c55c3e94ef097b217359ef0ce1abe739122399ac5b7
                       - name: ARGOCD_AGENT_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:cdb7b8e196f7b40cfd29643a85a9fd79d9800310114ea085db5a82f3546e8591
+                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:65d2f8411d0efc285b2e6c55c3e94ef097b217359ef0ce1abe739122399ac5b7
                       - name: RELATED_IMAGE_ARGOCD_AGENT_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:cdb7b8e196f7b40cfd29643a85a9fd79d9800310114ea085db5a82f3546e8591
+                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:65d2f8411d0efc285b2e6c55c3e94ef097b217359ef0ce1abe739122399ac5b7
                       - name: ARGOCD_IMAGE_UPDATER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:87714bdb6c5e444f42120ab8bd18440fa477a2334fe4875d8b63f8db3b81b9be
+                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:d0fcd82aefadafc675fc7e515bcdc3203917e3202e1a7e41ae49716433ca3854
                       - name: RELATED_IMAGE_ARGOCD_IMAGE_UPDATER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:87714bdb6c5e444f42120ab8bd18440fa477a2334fe4875d8b63f8db3b81b9be
-                    image: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:7c4624a79f3d788b5c790b7792cfc8ec58a73914d246a7d231285e758f2ac3e5
+                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:d0fcd82aefadafc675fc7e515bcdc3203917e3202e1a7e41ae49716433ca3854
+                    image: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:446d622629b0f9cf506eb040497a13166e9eea2ac1950d6d19db7675d616f53f
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -1029,32 +1029,32 @@ spec:
       webhookPath: /convert
   relatedImages:
     - name: manager
-      image: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:7c4624a79f3d788b5c790b7792cfc8ec58a73914d246a7d231285e758f2ac3e5
+      image: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:446d622629b0f9cf506eb040497a13166e9eea2ac1950d6d19db7675d616f53f
     - name: kube-rbac-proxy
       image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:e6bfbe1e3a33d6f146ca70c040d0232ab254f98847efd1b2a382685c331e53a2
     - name: kube_rbac_proxy_image
       image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:e6bfbe1e3a33d6f146ca70c040d0232ab254f98847efd1b2a382685c331e53a2
     - name: argocd_dex_image
-      image: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:a23ac8b59a2c3277c6f0a73c26f45c2058b21525829677fa9996e14cd748a4e0
+      image: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:db761c36083601bce4191547e51923197c2940362758dc463563c2fab01fb0bd
     - name: backend_image
-      image: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:f45a9aebd083a25750301a711758626e23f87a3645982112b3e03293147d8236
+      image: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:6f2d2c3ac261e6802d919127b23ab1310b99009b41dd95c595bf6a5d1b3569ce
     - name: argocd_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:f68c2895439e7c1f780a09aedf128baf9c129da38bce894bf2bb42abf5d6c451
+      image: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:88189118c6b213fb533b0aaaa907baab156d11903f0c62caae76505326231d0d
     - name: argocd_redis_image
       image: registry.redhat.io/rhel9/redis-7@sha256:3d31c0cfaf4219f5bd1c52882b603215d1cb4aaef5b8d1a128d0174e090f96f3
     - name: argocd_redis_ha_proxy_image
       image: registry.redhat.io/openshift4/ose-haproxy-router@sha256:31d16a1533730e682b55b2b870f4175f3eef8030667f1713a593733b9da8cd53
     - name: gitops_console_plugin_image
-      image: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:f39e1668c1981190529ce9264c4bb2be87c627985e580dbf64f0a76042b6bfba
+      image: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:eefdfc78f1a89911b151e469a89334e31fb6ebcc8767b8e27cf38a798a21e3a8
     - name: argocd_extension_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:6748e135958942d055cdfd1d2f20aee278b3b21e9937f6431bbd860948f6bc38
+      image: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:741b99d79c2d7b482bc3429287dd3ee9476b73754b0120fb63ca758c1322b5f6
     - name: argo_rollouts_image
-      image: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:41fdac243aa6c9af6f7ee6610ec6377de7316a9a769f4ddea7ec3016f0fcfcdd
+      image: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:0aafa78de280080c6f75aba32465ccd4038f53752240433a3dc1ebf70b976c75
     - name: must_gather_image
-      image: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:24e9a0cd96c392f28c070c71de34c6704a51dc98b316f1dd8b6fe4ba96ed2c61
+      image: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:df046b3d40bb5f011f9994f7611feaf581bad57902a5ac4ce93952e6026732e4
     - name: argocd_principal_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:cdb7b8e196f7b40cfd29643a85a9fd79d9800310114ea085db5a82f3546e8591
+      image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:65d2f8411d0efc285b2e6c55c3e94ef097b217359ef0ce1abe739122399ac5b7
     - name: argocd_agent_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:cdb7b8e196f7b40cfd29643a85a9fd79d9800310114ea085db5a82f3546e8591
+      image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:65d2f8411d0efc285b2e6c55c3e94ef097b217359ef0ce1abe739122399ac5b7
     - name: argocd_image_updater_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:87714bdb6c5e444f42120ab8bd18440fa477a2334fe4875d8b63f8db3b81b9be
+      image: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:d0fcd82aefadafc675fc7e515bcdc3203917e3202e1a7e41ae49716433ca3854


### PR DESCRIPTION
This PR updates the bundle files with the latest image shas for release-1.20 tag.

Automatically generated from `release-1.20` branch using GitHub Actions.