### PR TITLE
build(deps): update argocd-agent version

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -84,8 +84,8 @@ sources:
     commit: 09102635500867f4119ae63008bf1fe1ae7328b5
   - path: sources/argocd-agent
     url: https://github.com/argoproj-labs/argocd-agent.git
-    ref: v0.7.5
-    commit: 1a2e0e707ffd9b9d802f2d3ab7cd1742e351e422
+    ref: v0.7.6
+    commit: 727ac65eb923a420e33ac0b5a61f5352f03d15c0
   - path: sources/argocd-image-updater
     url: https://github.com/argoproj-labs/argocd-image-updater.git
     ref: v1.1.1


### PR DESCRIPTION
This PR is to update argocd-agent version to 0.7.6 which has fix https://github.com/argoproj-labs/argocd-agent/commit/db697dc9648278c15ffc488363a967e923fe29ed