### PR TITLE
chore(deps): bump ImageUpdater from 1.0.3 to 1.0.4

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -88,8 +88,8 @@ sources:
     commit: d8c7f9287090d963ba8b1ca5678079c7dc77a342
   - path: sources/argocd-image-updater
     url: https://github.com/argoproj-labs/argocd-image-updater.git
-    ref: v1.0.3
-    commit: e6e07a3b0ff9d8eb29b3735229c69924f80af27c
+    ref: v1.0.4
+    commit: 0da8b1b12381e854acf448e566bfa07c6c943984
 # External images pulled directly from Red Hat registry and are
 # required by the operator at runtime.
 # Bundle generation script will automatically fetch latest sha for each image 


### PR DESCRIPTION
https://github.com/argoproj-labs/argocd-image-updater/releases/tag/v1.0.4

~~This PR should wait for https://github.com/argoproj-labs/argocd-operator/pull/2175 to be merged first.~~