### PR TITLE
update gitops-backend commit id (1.20)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -69,7 +69,7 @@ sources:
   - path: sources/gitops-backend
     url: https://github.com/redhat-developer/gitops-backend.git
     ref: master
-    commit: 18ee1c620ddb72a282f64d682c3108f85aa82a85
+    commit: 1212ec223bfe8399f93ddbfc13be6dc074325d1d
   - path: sources/rollouts-plugin-trafficrouter-openshift
     url: https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-openshift.git
     ref: main


### PR DESCRIPTION
picks changes https://github.com/redhat-developer/gitops-backend/pull/66 to fix [CVE-2026-33186](https://github.com/advisories/GHSA-p77j-4mvh-x3m3) [gRPC-Go auth bypass HTTP/2 path validation]