### PR TITLE
chore: 1.18.6 Update gitops-console-plugin to pick up CVE fix (#9419)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -65,7 +65,7 @@ sources:
   - path: sources/gitops-console-plugin
     url: https://github.com/redhat-developer/gitops-console-plugin.git
     ref: v1.18
-    commit: ff5c4dfdfff4420429288e2323f3601ac467d0f2
+    commit: 62e7322919dec7639aa511eee0d3b9fc8d11a6b3
   - path: sources/gitops-backend
     url: https://github.com/redhat-developer/gitops-backend.git
     ref: master


### PR DESCRIPTION
See GITOPS-9419 for details, for 1.18.6

See v1.18 commits in plugin repo:
https://github.com/redhat-developer/gitops-console-plugin/commits/v1.18/

Specifically, the one we want:

https://github.com/redhat-developer/gitops-console-plugin/commit/62e7322919dec7639aa511eee0d3b9fc8d11a6b3

compared to the previous commit:

https://github.com/redhat-developer/gitops-console-plugin/commit/ff5c4dfdfff4420429288e2323f3601ac467d0f2


