### PR TITLE
chore: 1.19.4 Update gitops-console-plugin to pick up CVE fix (#9422)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -65,7 +65,7 @@ sources:
   - path: sources/gitops-console-plugin
     url: https://github.com/redhat-developer/gitops-console-plugin.git
     ref: v1.19
-    commit: c36e6a73ed888fe367e91583f77b1dda4dfd2f05
+    commit: 3379bd620d885b5f656c6d08961c6d7dced9d4cd
   - path: sources/gitops-backend
     url: https://github.com/redhat-developer/gitops-backend.git
     ref: master


### PR DESCRIPTION
See GITOPS-9422 for details, for 1.19.4

See v1.19 commits in plugin repo:

https://github.com/redhat-developer/gitops-console-plugin/commits/v1.19

Specifically, the one we want:

https://github.com/redhat-developer/gitops-console-plugin/commit/3379bd620d885b5f656c6d08961c6d7dced9d4cd

compared to the previous commit:

https://github.com/redhat-developer/gitops-console-plugin/commit/c36e6a73ed888fe367e91583f77b1dda4dfd2f05