### PR TITLE
Bump Dex Go Version to 1.25 for GitOps 1.19

### DIFF
--- a/containers/dex/Dockerfile
+++ b/containers/dex/Dockerfile
@@ -15,7 +15,7 @@
 # ------------------------------------------------------------------------
 
 # --- start build stage #1
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.24 as builder
+FROM registry.redhat.io/rhel8/go-toolset:1.25 as builder
 USER root
 
 COPY sources/dex /app/dex


### PR DESCRIPTION
This pr fixes CVE-2026-32282
Upgrade dex golang version to 1.25.