### PR TITLE
chore(bundle): latest bundle updates for v1.20.4-2

### DIFF
--- a/containers/gitops-operator-bundle/bundle/manifests/argoproj.io_argocds.yaml
+++ b/containers/gitops-operator-bundle/bundle/manifests/argoproj.io_argocds.yaml
@@ -1905,7 +1905,6 @@ spec:
                   NetworkPolicy resources for this Argo CD instance.
                 properties:
                   enabled:
-                    default: true
                     description: |-
                       Enabled defines whether NetworkPolicy resources should be created for this Argo CD instance.
                       When enabled, the operator will reconcile NetworkPolicies for Argo CD components.
@@ -18031,7 +18030,6 @@ spec:
                   NetworkPolicy resources for this Argo CD instance.
                 properties:
                   enabled:
-                    default: true
                     description: |-
                       Enabled defines whether NetworkPolicy resources are created for this Argo CD instance.
                       When enabled, the operator will reconcile NetworkPolicies for Argo CD components.

--- a/containers/gitops-operator-bundle/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/containers/gitops-operator-bundle/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -179,8 +179,8 @@ metadata:
       ]
     capabilities: Deep Insights
     console.openshift.io/plugins: '["gitops-plugin"]'
-    containerImage: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:73b844f2dd5f2e2749c66024801ed59539aa363aa18052018b8b80ede0ea544e
-    createdAt: "2026-03-04T06:59:29Z"
+    containerImage: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:655da6cbef2269018f4adea617c26c10c6c437bd7de560909d452ca7da4f6068
+    createdAt: "2026-05-20T03:47:13Z"
     description: Enables teams to adopt GitOps principles for managing cluster configurations and application delivery across hybrid multi-cluster Kubernetes environments.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -198,12 +198,12 @@ metadata:
     support: Red Hat
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/internal-objects: '["gitopsservices.pipelines.openshift.io"]'
-    operators.openshift.io/must-gather-image: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:9c27f8c025b8cb7e22f33537449773286d97c5475d31cefca8559c04a4249c43
+    operators.openshift.io/must-gather-image: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:e43afd4abc0e799d090eb5e5162472013a265f1aaa523adcbfce052452d1087a
     features.operators.openshift.io/cnf: 'false'
     features.operators.openshift.io/cni: 'false'
     features.operators.openshift.io/csi: 'false'
     olm.skipRange: ""
-  name: openshift-gitops-operator.v1.20.3
+  name: openshift-gitops-operator.v1.20.4
   namespace: placeholder
   labels:
     operatorframework.io/os.linux: supported
@@ -330,7 +330,7 @@ spec:
       - kind: Rollout
         name: rollouts.argoproj.io
         version: v1alpha1
-  description: "Red Hat OpenShift GitOps is a declarative continuous delivery platform based on [Argo CD](https://argoproj.github.io/argo-cd/). It enables teams to adopt GitOps principles for managing cluster configurations and automating secure and repeatable application delivery across hybrid multi-cluster Kubernetes environments. Following GitOps and infrastructure as code principles, you can store the configuration of clusters and applications in Git repositories and use Git workflows to roll them out to the target clusters.\n\n## Features\n* Automated install and upgrades of Argo CD\n* Manual and automated configuration sync from Git repositories to target OpenShift and Kubernetes clusters\n* Support for the Helm and Kustomize templating tools\n* Configuration drift detection and visualization on live clusters\n* Audit trails of rollouts to the clusters\n* Monitoring and logging integration with OpenShift\n##Components\n* Argo CD v3.3.9\n\n## How to Install \nAfter installing the OpenShift GitOps operator, an instance  of Argo CD is installed in the `openshift-gitops` namespace which has sufficient privileges for managing cluster configurations. You can create additional Argo CD instances using the `ArgoCD` custom resource within the desired namespaces.\n```yaml\napiVersion: argoproj.io/v1beta1\nkind: ArgoCD\nmetadata:\n  name: argocd\nspec:\n  server:\n    route:\n      enabled: true\n```\n\nOpenShift GitOps is a layered product on top of OpenShift that enables teams to adopt GitOps principles for managing cluster configurations and automating secure and repeatable application delivery across hybrid multi-cluster Kubernetes environments. OpenShift GitOps is built around Argo CD as the core upstream project and assists customers to establish an end-to-end application delivery workflow on GitOps principles.\n"
+  description: "Red Hat OpenShift GitOps is a declarative continuous delivery platform based on [Argo CD](https://argoproj.github.io/argo-cd/). It enables teams to adopt GitOps principles for managing cluster configurations and automating secure and repeatable application delivery across hybrid multi-cluster Kubernetes environments. Following GitOps and infrastructure as code principles, you can store the configuration of clusters and applications in Git repositories and use Git workflows to roll them out to the target clusters.\n\n## Features\n* Automated install and upgrades of Argo CD\n* Manual and automated configuration sync from Git repositories to target OpenShift and Kubernetes clusters\n* Support for the Helm and Kustomize templating tools\n* Configuration drift detection and visualization on live clusters\n* Audit trails of rollouts to the clusters\n* Monitoring and logging integration with OpenShift\n##Components\n* Argo CD v3.3.10\n\n## How to Install \nAfter installing the OpenShift GitOps operator, an instance  of Argo CD is installed in the `openshift-gitops` namespace which has sufficient privileges for managing cluster configurations. You can create additional Argo CD instances using the `ArgoCD` custom resource within the desired namespaces.\n```yaml\napiVersion: argoproj.io/v1beta1\nkind: ArgoCD\nmetadata:\n  name: argocd\nspec:\n  server:\n    route:\n      enabled: true\n```\n\nOpenShift GitOps is a layered product on top of OpenShift that enables teams to adopt GitOps principles for managing cluster configurations and automating secure and repeatable application delivery across hybrid multi-cluster Kubernetes environments. OpenShift GitOps is built around Argo CD as the core upstream project and assists customers to establish an end-to-end application delivery workflow on GitOps principles.\n"
   displayName: Red Hat OpenShift GitOps
   icon:
     - base64data: iVBORw0KGgoAAAANSUhEUgAAAXwAAAF8CAYAAADM5wDKAAAACXBIWXMAAG66AABuugHW3rEXAAAgAElEQVR4nO2dwW7d1rWGN504bpOmcjq5o+LE6LBAJc86qqQnkIz7AJIGnV3A8hNIegLJQOeSH6CQhE7uTBLQuaXOChSQhU7unTR2E6d1nJgXP03a5yqSRa69N7lJfh9AKHAOyU0e6efiv9daO8vz3AEAwPC5xXcMADAOEHwAgJGA4AMAjAQEHwBgJCD4AAAjAcEHABgJCD4AwEhA8AEARgKCDwAwEj7mi45DlmVfOue0zTnn7k79FPNDu14AAyflLs+dc6dTP5/lef6MGxoeWisEIMuyhVLQq2229xcF0D1n1QPAOXec5/kx34kfCH5DsixTlL4wtSHuAO2hh8BxteV5/px7Xx8EvwZZlilqXy43BB4gHfQAONCW5/kp38uHQfCvoRT51VLkJ0kOEgCmuSjFfw/xvxoEf4pyonW13BB5gP4i8d8rxZ8J4BIE/63QVyJP9gzA8DgphX9v7N/taAW/nHxdJ5oHGA1V1L8z1sne0Ql+adtUQj+TwJAAoF1eTAn/qOye0Qh+KfSbzrmVBIYDAGnwRLowFuEfvOBPWTcbCQwHANJkawxWz6AFP8uy9TKqx7oBgJt4UUb7O0O9U4MU/LLVwV6qk7EzMzNubm7uyv+3sLDQ+ngAYnF8fHU3hNPTU/fixYtU77smd1eH2MphUIJf2jcS+qWuxzI7O+u+/PLLQti13b17991PAHjL8+fPC/Gvfmp79uyZOzs7S+EOHZbCPxibZzCC36V9M5lMisi8EneidAB/9HZQPQT03xcXF13c1UHZPL0X/DKqP2i7aGppaakQ9uXl5SKSB4C4KPI/ODgoxP/w8LDtu63ireW+R/u9Fvwsy5ZLCyd6VC/fXeJebQDQLRL/amtpPuBFafEc9PWr76Xgl1G97JuHsc+lSF4Cv7q6GvtUAGBkb2+vEP6WIv/Hpc3Tu2i/d4JfFlAdxGxTrGh+fX29EHnsGoD+INtH4r+zsxM76j8rLZ5eFWz1SvBjWziafN3c3CSaBxgAEn79PUec7O2dxdMbwS+zcLZjHHt+fr6I6PHmAYaHrB5F/CcnJ7Gu7VFfsnh6IfhZlu3F6IGjiF5RAGmUAMNH2T16e48U8T/J8zx5a+BWAmO4Fk3OZll2HFrs5dHv7u4Wfh9iDzAO9Leuv3n97UsDArMirSoTSpIl2Qi/vHHHoSdnNzY2CvuGileA8aLKXtk8W1tboe+BJnMXUs3gSVLwY2TiyKfXF3xdDxsAGB+q4lUAGNjfTzaDJzlLp1w8/DSU2OvVbXt7u/DvEHsAmEaaIG2QRgS0eaRdp6WWJUVSEX55g45DpV2qgZlm6MmlB4CbkL+vTL2AjdtelPbOaSo3P5kIv7Rxgom9vHq9riH2AFAHaYU0Q9oRCGnZcaltSZBEhB9yglavZYrqyb4BACuyeRTtB6rWTWYit3PBDyn2snD0RZGBAwC+KJNHgWMgiycJ0U/B0gmSjbOyslK8jiH2ABACaYk0RdoSgNlS6zqlU8EvK2i9+9jLc1PFLABAaKQtgXz9+VLzOqMzSydUbxxVzdHsDABiI+FfW1sLcZbOeu90EuGXXS+9xL5qj4DYA0AbSGsCtWXYLjWwdVqP8MsUpVOf9EvdcAqpAKAL5OtrMtczg0c7z7VdjdtqhD+1/ixiDwC9pKrO9Yz0tfNB283W2rZ0Nn0ychB7AEiBQKI/W2pia7Qm+KVn5bUGLc3PACAVpEXSJE8etunnt+Lhl68tz3ysHCZoASBFAmTvyM//so2irLYifC/fXjmwiD0ApIi0yTNPf6atoqzoEb5vvr2q3CiqAoDUkfA/efLEZ5TR8/OjCr6vlaPeOEqBAgDoA/L1PXrvRLd2Yls6e1axrzJyAAD6gmfmzkypmdGIJvhZlqk/8ZJ1f7U4phEaAPQJaZa0y4OlUjujEDPCNz+pNAFCP3sA6CPSLs9J3GhRfhQP32eiFt8eAIaAp58fZQI3uOD7TNTK+2JZQgAYAlojV6Jv7LkTZQI3hqWzbp2o3dzcROwBYBBIy6RpRmZKLQ1K0Ai/7IR5btl3fn6erBwAGBzy9E9OTqyXdS9kR83QEb75cRagJwUAQHJ4alvQ5mrBBL+M7k2LP2pGm6ZoADBEpG0eWTsrpbYGIZilk2XZjqUbpiZqNblBzj0ADJXnz58Xnr5xAvdxnudB/PwgEX6ZmWPqbqbXHcQeAIaMNM7D2lkNtVBKkAg/yzL5TI3fWSaTSRHdAwCMAUX5FxcXlivdyvPc288P5eGbonu6YALAmPDQvCD94b0FP8syDWTSdD+lYdI+AQDGhDRP2mdgUmqtFyEifNMg1teD1xQAACSPh/Z5C76Xh28ttMK7B4Ax4+HlexVi+Ub4pieOR7kxAEDv8dBAryjfN8J/1tS/V969clIBAMaMUjUNefkXeZ6bC7HMEX6WZXOWyVq8ewAAsxZOSu014WPpmF4ttNAvAMDY8dBC844+gr/cdIelpSXaHwMAlBO30kQDjbW3wiT4Vjtnedk8TgCAwWHURLOtY5q0tbRSYLIWAODHGCdvTa0WrJZO48cS0T0AwI8xaqNpp8aCX3Ztm226H4IPAPBjjNo4a+mg2djSybJMo9tveqLQi6UDAAyFLMssV/Igz/ODJjtYLJ3GHc+MM9EAAKPAqJGNtbgVwacrJgDA9Rg1svFOFkunsTdzfn5O/j0AwDWomeS9e/ca3548zxt5QY0i/CzLGj9R1BkTsQcAuB5ppLSyKU01uamlg50DABABo1Y2KsBqKviNQ/W5OXOfHwCA0WDUyqiC33hECD4AwM20IfiNJm0tE7bk3wMA1MOSj99k4rZ2hF8uZ9iI2dnGBbkAAKPFoplNtLmJpdNY8MnOAQCoj1Ezowg+/j0AQERi+/hNBL9xox4EHwCgPkbNrK3NUSN89XkGAIComkmEDwDQN1KK8JuPgggfAKA2sTWzdh5+0xx8ljQEuBk1zdJWB2VwkPk2fCxLHtbNxf841t3DzgF4z/HxsTs9PS3EXT+1GdYxLVAwpb8vbXoA6Cc9q4aDvs+Tk5Mo1xNN8AHGjAS+2kL/8epBoWNePu78/Hwh/NUGcBkEHyAQBwcH7zZr9O5D9RDY2toq3gK0Vmq1AbjYk7YAQ0cWzfr6euG7PnjwwD158qQTsb+MxqCxaEwam8ZYd64AhguCD2BAVo1sE61S9Pjx4yRE/jo0No1RY9WYNXYYJ9EEn5RMGCJ7e3vFROni4mK0ibWYaMwauyYGdS0wLqIJPlk6MCSqiH5tbc1dXFz0/srOzs6KayHiT4+Y2omlA/AB5Htr0rOvEf1NVBG/rhGPPw1iuiMIPsA17OzsFNHW4eHh4G+RrlHXqmuG4YLgA1xCka7E79GjR0lPxoZG16pr1rUT7Q8TBB9gCk1kSvDkcY8VXTuTusMEwQdwruj7tLq6Wkxkjimqvw7dA90L3RN6Yg0HKm1h9EjQlK3SdlQ/mUzeNUS7qSla1WRNW5tZQireUt8fZfKQat1/EHwYNRIziX3sqF6tDqoeNyGanVXN2Kp+PTHHrwehHkg6D+nW/QbBh9ESW+wVwSvdUbZIaKGsHh5qmeDKa5Hnrj4+Md4AdI+qnH1Ev7/g4cMokTDGEvuVlRV3dHRU2C9VamdsqpRKnVPn1hhCU4m+7h30EwQfRocES03FQoq9LJuNjQ13fn5eRNpdtifWuTUGjUVj0thCoXume4fo9xMEH0aFrA9ZLCGRqCqy3tzcTGpFKo1FY9LYNMaQ6B7qXkK/QPBhNIT27JeWloooWqKacgaLxqYxaqwacwgqewfR7xcIPoyCKvUyhNjLItnf3y9sjT6tMauxaswaewibpxJ98vT7A4IPgyek2CtCrhqq9ZWqUVqIaB/R7xcIPgwepS6GKKra3t4uIuQhFCDpGnQtuiZfdG+r9FBIGwQfBo2yVVQt6oPsj6dPnw5S1HRNujZfi0f3mN476YPgw2Cp1pv1YXZ2dvDFRro2XaOu1QfWzU0fBB8Gi7xqH99+DGJfEUL0da9Dp7xCWBB8GCSqOvXx7SuxH1PDMF2rr+hrBS0WUUkXBB8GR1UEZWWMYl8RQvSrYi9IDwQfBoe8ZKuVo8lLTT6OuRWwrl33wDqRq3tP1k6aIPgwKBSd+qxBSzfIt1SevhV9Bz77QxxojwyDwsfKUU56V2L/w+mpy68pXsru3nUfdTAu3QvdE61za0HfBaKfFgg+DAbZEJo0tKCq07ZsCAn798fH7vXxcfHzh5qTyx/NzrqPFxbc7YWF4mfWgu2ke2J9a9J3oe+EzJ10wNKBwWCN7ivfPjYS95daI/aLL9w3Dx64V48f1xZ7oc9qH+2rY+hY37cQQfv4+WTspAWCD4NAUah1pafYk7QS5a8XFtzXi4vuO8+q32l0LB1Tx44p/NUkrgWlxmLrpAOCD4PAGt3LyonVCO3Ns2fvhP57o9VUBx27Ev43kdIhdY+szdZ85lUgLAg+9B7lfFu9+1iWw3d7e+6fc3NRhf4yOpfO+V0ke8p6r/TdkJefBgg+9B6rEGkVqBj97OWtv1xbc3mkxdE/hM6pc7+MMFGqe2VdOQsvPw0QfOg9Fn9Zk5Chs3KUfVNE2AF9eisag8ZyXaqnFd0zywQunTTTAMGHXqOe7paqWglXyIlaCas89CZZN7HRWDSmkKKve2Z5UOo7YuHz7kHwoddYRSR0bnhqYl9RiX5IrPcOwe8eBB96jUVEVlZWgnr38stTFPsKjS2kp697p3vYFAS/exB86C3K77bYOSGje2XEpODZ34TGGDJ7x3IP9V2Rk98tCD70Fot4TCaTYtHtECjn/dsedYXUWEPl6ese6l42BcHvFnrpQG+xiEfIIivZJKFSL29NJkV/nFuXrCYJtKpo3xiriKcpUjZXV93ngURX9/Lx48eN9kHwuwXBh95iKbYKZedIhEMUVX2ysuJ+sr5+YzdMddP8986Ot32kMWvsHwd4y9G9bCr41gI5CAOWDvQSS6So/PFQ7Y//5dku4PbSkps5P3ef7e3Van2sz+iz2ue2scVBhe/YK3QvLTn5RPndgeBDLzk9PW087FDevW90/+n2tvvZwcGP7Js6aB/tq2OYx19G+SGw3FPLdwdhQPChl1h6s4QS/Fce2S6f7e66OwEmenUMHcuKzzVMY7mn9NXpDgQfeoklSgxh56hq1eqjKyr/JGBKqI5ljfRfHxwEqcC13FMi/O5A8KGXdGXpWK0Q+e4hIvvL6JgWT18ZOyFsHSydfoHgQy9pWnBlyRm/itdGkfw0YrdI67Gt13KZpvfWUiwHYUDwoXdYPOBQrRQsUbFSLy0TtHXRsT8xtDoINXFrubf4+N2A4EPv6FLwLT1zftJCNa7lHKH6/yD4/QHBh1EQQvB/MHjPqqCtk2fvi85xy2BbWa7pMjEWkYE4IPgANbFktYSoaI15rtALpEDaIPgAEYnp3V+mzXNBP0HwASJyK+CqWgC+IPgwCkJV2TblzQgsk5BLRUJcEHwA8OI58wC9AcEHiEioBUfq0Oa5oJ/QD39kKP+5bg600u1IuXtPZrAuQhU3xTqX5ZqgvyD4A0U9x9WzROKun9qsJe1VH3ltegDoZ1eeeJdY8um1UpVy3WPn4uscllWxQoyLIqr+gOAPBAl8tYVeVUgPCh3z8nHn5+cL8ddSd2N5AHw0O9u4QlUrVX0WcAHx687RFF1LCLqsfIZmIPg95uDg4N3WRUOq6iGgZe70FiDhr7ahouKmpoKvdso/3dyMlicv797SsjlUURiC3x+YtO0Z+uNaX18vUuEePHjgnjx5kkT3QY1BY9GYNDatdzrENri3jSL5bcR+OtZjW6/lMhcNrSTLsogQBgS/J8iqkW1y7969IqJOucVsJf73798vxqw3kKFgjYpfHx66VxFaJOuYOraFEBG+ZX3aUOsKQ3MQ/MTZ29srXn8XFxd7ueK/xqyoX9ewF9nHbgNltVhaEYtvHz1y3wW8BzqWjmlB19BVhg6C3x0IfqJUEf3a2lrjV+YU0TXoWiT8lqgwJe54LFP4cm0tSKSvY+hYVnyuwRf8++5A8BNDHr0mPfsa0d+EhF/XpodZX9P5ZIV8PD9v3l9R+TfLy6ZCKe2jfa2RvdDYQ03YWtoqEOF3B4KfEDs7O8Ufw6HRk+0TepjpWjc3N3s5/p96jlu++4t799zL1dVaPen1GX1W+1g9+wrfsU+j77DJEof67BhrOFKBtMwEqKL6s0ArEPUFTe5ubW0Vk7ry9/sU+VVR/veeb2FKp9SmxUt0TKVuqsNm1XRNEb0qaC1FVVeR/cd/BO/Rr0BF8zR16OsDfigg+B0joVOa5ZgXdtaDTlGfxGC9heUAQ6Fiqn/Ozbk8wHcnQbfk0jcl/9//Ld4UQhaCKVhZWVkpMrM+hD6z2uHcAWDpdIY6DOqXXxOZrOL/Ntp/9OhRrwRB0finEVItY6MHy8vA91mBy/7+/pX2jv5td3d3EFlafYcIvwMk9opo27Zw9IdXNUS7KVOiarKmrc0sIUWJujd9Ef5PVlfd6+PjVqLzkFTjDR3pa6t6OGlCVxuTtOmA4LeM/hgkaLGjelUz6jzaQjQ7q5qxVf16Yo5f1k6fIn2JpiZVm7Zc6JoYou/KiVxEPk0Q/BaJLfaK4BVhSSxD/8FVD4/KY9e16BVdE66h3wB0vKoOoS98fnzsvjb02emaWKIPaYKH3xISxlhir8mwo6Oj4jW6Su2Mjc6hc+mcOveKsfr0Ovq2ipKqViX6oTpQtkkMTx/SBMFvAYm90tZCir0sm42NDXd+fl5E2l1Gwzq3xvDVV18VYxprcyyJ/s9PT82tF7oE0R8HCH5kZH2E9qMlqoqs5XWnVKauCTqNSWPzFf4+L4wte+Sz3V2X9ezBh+gPHwQ/IqE9+6WlpSKil6imLIiV8Ov6NeamDKEaU9k7ivZ9WjA0RUVVviD6wwbBj0SVehlC7BUpK8dZ1lCfGk9prBqzPP4m5fdDqcZUnr58/c+PjqIKv46tc9z9n/8JYif5iL6ylVQZfNVWp4UExIUsnQiEFHtFyPLH+2xx6F5U1tZNfYKGWI2pVgaflwL4am8vSM6+7KLby8tF18vpVglVto3vOepk7+TPnxfX9Lq8troZSprY1pi1AIt+spB6i+R5XmvTR5tsGxsb+VhZWVlpdK+u27a3twd3B/f39/PJZPKja9a/7e7u1jrG0dFR43upfVLhzVdf5d/t7+ff/Od/5v9wrtGmfbSvjvEhvllZaXzsqzYd5zKvj46CHb86x+uEvp+ukXY2/f2uq+NE+IFRNH5TT5GbkIWjPPQhFq9U1Zi6vir1Um8vY+qgqIhW0bl+fvfHPzba985//Vet5mcxIn1F8f/a3PRuGHfVObTJmlInz9DN3eA9CH5AqvVmfZidne1d50gLtMiNT0jRf/3f/100XouJHiRfLy4Wwq+xx1r0fcwwaRsQRa4+vr3EfqiRPXSDhDPERG5ssZ9Gwq8upCGXg4S3IPiBUNWpTzO0Suz7PDkLaRJK9NtELae1hCMpomFB8ANQFUFZQewhNn0UfVfaScWaAz1rtZEqCH4AfBYw0QRt39MuoR/0VfSV7qnGdIi+Pwi+J4rMfdagxbOHNum76IMfZOl44mPlbG9vI/aJogdxxdAW8QiVvdM2Ev3QyzOODSJ8D2TFnBhzklVB26f1W8eCvlO1hFhcXHy33b9/v/i3IS3R12dPn+wdOwi+B9bovvLtIS2qNYavWtBF/6b/p9TbvvXqv46+iv636+vuzbNnCYykf2DpGNErv3WlJyZp00NN3upUSGu+por2Jf59R6Ifsqjq1mRSVMpeLpqSQKtS902A1dGKlM3V1aI/ETQDwTdije5l5QxBKIZGE3tNGVla0Ebfpeov+tTB9DIS4RBirzeFn6yvu49umOtQx8x/7+x4zx+oOEtjpw1DM7B0DCjv3urdSyAgLaxva4r2NZmrh39fbZ5/ebaivr205GbOz4s3hZvEXugz+qz2uW1YK2Ea37GPEQTfgFW0tQpUn6NB+DGK9re2torvtW/CX/Ss92iE9un2tvvZwYGp54320b46hpUqyocG95171RzLhKsmasnKGS6V8H/xxRe9WcDllUfigJZwvBPg91nH0LGs+FzDGEHwG6LJPUtVrcSeido0Cf29SPhTX8RFVatWH11R+ScBr0/Hskb6rw8OqMBtAILfEAm+haGt4jQk5MM3WYKxDsr4STnSt1oh8t1DRPaX0TEtnr4ydrB16oPgN8Qi+Fq2D+8+bWKIc8oT9K+NIvlpxGuyHtt6LWMEwW+Asjksdg7RffroO1oJXISk35XjRMXIEhUr9TLmoiQ6tqUQjAi/Pgh+Ayx/vLIKWN2pH2gyXv2NNMEeilSzduouOD7NT1pIOrCcw3ItYwXBb4BF8Cmy6heaXNf3rDUKQpDiRL2Kn5qiCto6efa+6By3DPMplmsaIwh+AyzFVtg5/UOTuKenp0XdhG+0n6LgW7Ja2qxotZyLTJ16IPg1sUT3EgvaH/cXTeRK+Ofn503XIDtvKN9/mwuKs3h5PBD8mpwaXhnx7vuPsqv0sD86Omps8wypI+otakgGAYJfk2eGdqwI/nDQd6mH/u7ubq2cfX1uSN//GyyTQYDg18QS4WPnDA/Nyejhv7+/X3TLvOzxy/7R2wBzN5AitEeuCZYOTKPsqyoDSw8AbXrAD7V9RpsLjrC4STwQ/Jo0LbgKXaoP6SKfv0+V1JnhodRmcZPlXJZrGiNYOjWw+Pe0UoBUseTTa6WqNnLddQ7Lqlht1AgMAQS/Bgg+DI2PDIVl/26hN5DlHJZrGSsIfiQQfEgZS3GT2inH9Nd1bEvLZpY5rA+CDzBCbhtF8tuI/XSsx7ZeyxhB8AFGiDUqfn146F5FsHZ0TB3bAhF+fRB8gBGirBZLK2Lx7aNH7ruAVcQ6lo5pQddAhk59EPxIsJxhPFLtMd837ngUh71cWwsS6esYOpYVn2sYIwh+JFLtgw5QISvkY2NjOFdG+t8sL5smcrWP9rVG9kJjx85pBoIPMGJ+6rm0o3z3F/fuuZerq7Xy9PUZfVb7WD37Ct+xjxEqbQFGTBXlf29Y62EapVNq0+IlOqZaHKvDZtV0TRG9KmgtRVVXQXRvA8GPhKVYC+rBvQ3LZ3t77p9zcy43rNd8GQm6JZe+CdnMTDFmaA6WTg0sRVSIUjyofA6LovFPW6iiDYXGyiIpNhD8GiD4aYHgh+eT1VVzmmar41xZKcYKNhD8mjRd2/QikFcJ/vfWd13asSCbJOW+NBobVo4fCH5NLIuZkC8eHss9ZSGa+nx+fJyk6GtMn/P35A2CXxOLaFgWTYHw9xQ7pz6qWk1N9Cuxp6LWHwS/JhbRIMIPDxF+fCSsPz89TcLT1xg0FsQ+DAh+TbB00gDBbw/55Z/t7hZpkG1TpF7u7uLZBwbBr4llfVoti4itEw7dy6ZLTTrWFvZCGTGKsH1aMDRF5yreMMjGCQ6C34B5wy/9HhFKMCz3cpbVkLxRzrs89M+PjqIKv46tc+hc5NnHAcFvgCVSPDg46HDEw8JyL1OM7vPnz93rgwP36g9/aLyv9tG+eQfN+dTKoBL+UP6+rBsdqxJ62iXEBcFvgEU8lDOOl++P7BxLbUNKgq9eMmoc9vyLL9w3Dx647/74x8bH0D7aV8fQsb7v4HdLoixv/e5XX7mf7e+7Ow8fNsrq0We1j/adefasOBZC3w700mmAxENFPE19ZFkR+Mh+7BhK//VdLS8vdz52ifK/Nje9G5RdpmpYJitEnSPbFk1lztxeXi62CnXDvO7tQ5//iAn0TkHwGyIBedKwOZQ+v7m5ST64Ea0t0PSeuwSie3WILKLwwEJ/GR3/68XFQvgVLXfpfyPoaYOl0xBrxMjkrR1LdO88vqsQfFd2oIwt9tPoXDpnyOUHYVgg+A2RiFh6s0i0WAWrObpnVjtntaO0PkX1WrYvRLvhpuicOvdLUhrhChB8AxYhke9vjVTHjO6ZJfe+i+he3nURYUfuB18HjaHocU+QAVMg+AbW19dN+21tbdE2uQHW6N55fEdWJKxfLyy4H87OWj3vh9BYNCZEHyoQfAOafLUUYbkWhUgPFqWDKnddP/toJ+leWaJ7FVu13U4hNbGvqEQfwCH4djaNCygfHh5GLcZSvrqyU+7du+cWFxfdgwcPip9ffPFFIaB9EX49pCyZOa6D6L5YwDtBsa/Q2PD0wSH4diSq1rJ9zQHEEF6JpMZ1ck1myOPHj4v/n7roa3zWCdfJZNLqZK0yYlLw7G+iyNkne2f0IPgeWCNJ2RShRUkWjiYqb7JAzs7Okhd93VfrimHWNy8LyrP/tuW3CR801jfMIY0aCq88kGgrv/66iPpDyNrRhGQo+6FJNksl+nojuJtYn3HdT6uV03Z0L5skVOrlrcmkqJS9XDQlgVal7psAS2YWKZurq6wcNWbyPK+16aNNto2NjXwMHB0dNbovl7enT58GuUuTyaTxuWdnZ/OvvvoqmW9J92JmZsZ8L/f391sb6+ujo/wfznlv36ys5N/X+B3QZ/TZEOfU2CFdpJ1Nf/fr6jiWjieKlJeWlswH0f4heuZbLJCU7B2NQWOxZOW4snV1m7n3//K0jm4vLbmZ8/O3C4fXyCjSZ/RZ7XPb4/fNBRg79BcEPwCyUyzVt27Kz+9KdFMQfV+xdx7tFyzIYvFpmfDp9rb72cGBqeeN9tG+OoZ5/CcnnXTZhO5B8AOgvHyfycIQoiv/usvzW6nE/swjrXFjY6PVvPtXHtkuWrbvToB5Gx1Dx7Licw3QXxD8QGjy1VqM5QKIrq+d0YXohxB7pca2mZmjqlVrGqai8pDL9ulY1ki/q0VUoFsQ/IAow8Rq7bgp0bV4+nrg+JzbtSz6SiP1FXvXQRdSqxUi3z1EZH8ZHdPi6StjB1tnfCD4AZG14+slW0Vf51aaZR9EX9cmC8ZX7Le3t1tvoUYHA4kAAA6wSURBVPDaKJKfRpxjsB7bei3QXxD8wGgCdsVzvU9NXt6/f7/xw0Pil7roKyLXtflM0AplRrXdQsEZI3yt2RpzURId27LGLBH++EDwIyChtrZdmObRo0eFN99EeFMWfT0M19bWvI+je9vVgjKWnjk/aeHBZDlHyv1/IA4IfgRUvRpCdF1ZkSu7pknDtRRFX+O3VtBOo2uS2HdRIfyDYW5FFbRtLPunc9wyZGpZrgn6C4IfiZCiL/tDXS8V7dftp5+a6IewX3Qtuqa2ffsKS1ZLmwuLW85Fps64QPAjEkp0KxTtq+2x0hDrCHAqoq9JWmsztGlklXUl9lbaXFC8y8XLoR8g+JGRQIX2m7VyVlXsdVPEn4Loh7CEdnd3O1uj1odbiTWng3GD4LeArJj9/f1gkb4rbR4JvyJ+CeHxBzIu+pC98yH6KvbiDZYJJASC3xIS/ZD2zjSaDNWqVor65ZVflcPfpehbJ1g1Vj0o+yr2AKmB4LdIaE//MvLJtaqV8twlsnrIyPeuov+uRF/nbdrrp5qgbbMDZgzaXHCExU3gJhD8lpH4yXcPkaf/IWT5aJJXufyK/rMse/cG8Lvf/c7duXPH6/gS/d/85je1Rb9JEZnuTVWNmxKZ4U2lzeImy7ks1wT9BcHvgCpl07cityl6A9DqXH/605/cq1evvI/397//3f3qV7+qJfqK1Otcrz6je/Nlghknlnx6rVTVRq67zmFZFauNGgFIBwS/IyT6yt7RhGQsi6cN/vGPf7jf/va3tc5UXe9V9o7+Tf+vq6KqunxkeDP7dwu9+i3nsFwL9BsEv2M0ISn7wqe1ctf89a9//WCW0DS6XllaT58+dUdHR+82/VsfJmctxU1qpxzTX9exLS2b2ywKgzRA8BOg6nSp7o99jfb/8Ic/NPq8/HlN/FZbX7htHOu3EfvpWI9tvRboLwh+QlQplT5r5HbF3/72t2F9GddgjYpfHx66VxGsHR1Tx7ZAhD8+EPzEqBqlyebos80zVJTVYmlFLL599Mh9F7DqWsfSMS3oGsjQGR8IfqLI5pDNo4nM2CmcIfj1r3/dzxtt4I7HXMPLtbUgkb6O8dKj1bTPNUB/QfATp5rUTT3i//3vf5/AKNpBVsjHHt+FovJvlpdNE7naR/taI3uhsWPnjBMEvydUEf/5+bl7+PBhUpO7iu77NPEagp96Lpwu3/3FvXvu5epqrTx9fUaf1T5Wz77Cd+zQXz7mu+sX1bq52uT1V5vvkoFWfvGLX7g///nPo/oO3FSU//3JiddxlE6pTYuX6JhqcawOm1XTNUX0qqC1FFVdOW6i+1GD4PcYVa9WvWYU/VfbiacI1eWXv/yl+8tf/pJ0oVRMPtvbc/+cm3N5gIetBN2SS9+EbGamGDOMFwR/IFzOZ5fwy/tXQZN+agv5FqCJZJ1jrGLvygVHPvWcPG0TjZVFUsYNgj9QripoUtuCUIuIj13sKz5ZXXWvj4+jR+e+KA3zEzJzRg+TtiMBsY+HbJKU+9JobFg54BD8cYDYx+fz4+MkRV9j+rzFFs2QNgj+wEHs20FVq6mJfiX2VNRCBYI/YBD7dpGw/vz01Nx6ISQag8aC2MM0CP5AQey7Q375Z7u7RRpk2xSpl7u7ePZwJQj+AEHsu0cZMYqwfVowNEXnKt4wyMaBa0DwBwZinw7KeZeH/vnRUVTh17F1Dp2LPHv4EAj+gFCLBcQ+PdTKoBL+UP6+rBsdqxJ62iVAHSi8GgihlghE7ONR9N9ZWCgqXtUfRwVb+vnD2VmtcyrrRvvfLo/DhCw0BcEfCGqm5ts6AbFvBwn17eXlYqtQN8y8bJh2GX3+o7m54d4QaA0EfyDIzvEBse8WBB3aAA9/IFx4tM9F7AHGAYI/chB7gPEQTfBPa6ziA+GYTCaNj4XYA6THccTeR9EE//k1E1AQh+WpCcA6IPYA4wNLZyCsr6/XXucWsQcYJwj+QNBatxLxm0QfsQcYLwj+gJibmyvEfP6aMv6HDx8i9gAjhjz8gVGJvipvtVXo3xF6gHGT5Xle6wZkWVbvgyWyFpi4BQBohgKzplXzeZ5ndT7XxNI5aTIA3zJ/AIAxYtDO2toc1cMnwgcAqE9szWwi+I1HQvEVAEB9jJpZW5ubCH7jkRDhAwDUx6iZtbWZCB8AIBF6HeEj+AAA9TFqZpQI/1mNz/z/HZ413gUAYLQYNbP2TrXz8J0hF9+9zQ9tugsAwCjJslrp9Jc1tvZOTdMy6y2+OUXMVp8AAEPBqJWNNLmp4OPjAwBEILZ/7xB8AIA0GITgY+kAANyMUSsbaXKjSVtnnLg9Pz8v+rUDAMCPUXbOvXv3Gt+ZJhO2zthLp/HE7cHBgeE0AADjwKiRjbXYIviN3zuwdQAArseokY13slg6Wi17v+mJyMcHALgaS/69c+5BnueNXg1aifAdtg4AwJV4aGNjLW4s+HmeP8fHBwAIg9W/L7W4EdYFUBqPEMEHAPgxRm007dSa4GvZrr29PePpAACGhzTRuBxse4Kf57mS/S+a7keUDwDwHqMmXpQa3BifNW0bj/Tw8JCWyQAAZbGVNNGAOXL2EXyTP4OtAwDgpYXmHRvn4f+/nbNM4fqkyT4zMzOsdQsAo+fu3bsW/152jrlPjU+E7yxPGiZvAWDseEzWeomnb4SvJ8150/0mkwlePgCMFjWTvLhonPci7uV5bhZPrwi/PPFJ0/10oWTsAMAYkfYZxf7ER+xdAEvHWV8xdnZ2ApwaAKBfeGiftxfuZem8O4hh8lYcHR25hYUF7/MDAPQBdcVcXFy0jNRrsrYiRITvrE+e1dXVQKcHAEgfD80LkukSSvD1jtI8v+jigowdABgF0jqjd/+i1Fhvglg67q2towE9bLqf8vKVsaOcVACAIaLaI2XmGFMxH+d5vh7itoSK8J31CaQbwAQuAAwZaZxR7F2o6N6FjPDd2yhf/syKZd+nT5+6ubm5YGMBAEiB09NTd//+fetInuR5HmyyM7TgmwqxxPz8PGvfAsDgUCbiyUnjcqUKr0Kry4S0dKpCrC3LvrohWDsAMCSkaR5ivxVS7F3oCN+9jfI1+6pBzjTdVxO4ev3R5AYAQJ9RMopsaqN3r52+tCxj+CGCRvju/Zq3m5Z9dWOWl5dDDwkAoHWkZR4TtZuhxd7FEHz3VvR3LCtiibOzM7e5aXpeAAAkgTRMWmbkotTQ4AS3dCqyLFPPhCPr/rRdAIA+4tE+oWIxz/MoGSzRBN+9FX21xFyy7EtBFgD0Dc8CK3GY53k0XzuKpTPFqqXlgiv9fCJ8AOgT0iwPsX9RamY0ogq+zwSuK/18GqwBQB+QVnn49i7WRO00sSP8agLXnIj65MkTJnEBIGmkUdIqD05iTdROE9XDr/DJza/Y3d0l2geA5FAXzLW1NZ9hRcm5v4roEb57b+14qbVuKK2UASAlAoi9WG1D7F1bEf67kxlbKFcoc0cpTzRZA4CuUVcAz0laF7L1cR3aFnxZO8ovnbUeA9EHgK4JJPaa4V1oK7p3bQu+e99R89THz0f0AaArAom9dp4L3RztJlrx8KcpL9DLz69y9PH0AaBNpDkBxN6Vvn2rYu+6iPDfnTjL5Ftt+x6H7B0AaINAE7TiURspmFfReoRfUV6wV+KqK7N3yNMHgJhIYwKJ/ZOuxN51GeG/G0CWaRJ33vc4KysrWDwAEBw5CJ5FVRUqruq0X0wKgu+duVMxOztbTObScA0AfFEjNPn1nu0SKlrPyLmKziydivIGLJQ3xAt9MepUx9q4AOCDNERaMiSxdykIvnsv+svWzprTaPZcvajx9QHAgrRDGhIgE8eVmpaE2LsULJ1psiybK+0dc47+NLJ4Dg4OWCMXAG5E629oWcJAUb2bEvvTVO5+EhF+RXljFkJE+q60eFScpZXjAQCuQxohrRiy2LvUIvyKshr3IMREbsX8/Py7LxUAwJVVs+vr6+7kxNzB/Sr01FjuorDqJpIUfBc4e2eajY2N4gsmkwdgvCgDRwHg1tZW6HuQzATtVSQr+O696B+EyNOfRr149GVToQswPlSvo6Av0KTsNCdlZJ+k2LvUBb8iyzJVVK2EPu5kMnnXGwMAho1SLRXkXVxcxLhOVdAmH0EmNWl7HeWNfBT6uPrilX4lwVc2DwAMD/1t629cf+uRxP5RH8Te9SXCr8iyTLn6e6HSNi+jiF85uFg9AP1Hb+/6e44k8q7MxFHXy95Ei70SfBcpg+cy8vjl8Un4yeEH6A/KpZfQa44ugkc/TbKZOB+id4Lv3k/mbvosl1iXpaWlohiDqB8gXSTysm4ODw/bGONj6U/Kk7PX0UvBr4ht8UyjqF/CX20A0C0S+GqLHM1X9M7CuUyvBd9FTN28CUX+mgiS+GP7AMRHdo3EXdk2LUXy0ySfclmH3gt+RbmC1mYb0f5lNNkr8VcVrzbSPAH8kbCrElab/jvi5OuHeFHaN4PozzIYwXfvo31ZPEtdj0WN2xT5Vw8BVfZWPwHgLap4laBXP7Upkg/Y08aHw9LC6XVUP82gBL8iy7KFUvgnaYzox6i3z1XwdgBD4rq1KSTsLfnuFi5KoR/cwhqDFPyKLm0eAOgdg7JvrmLQgu/e2zwS/o0EhgMAaaIuajtDsm+uYvCCX1EWbG3G6MkDAL3lSRnV96qAyspoBL+iFH5F/KtYPQCj5EU5x7czFqGvGJ3gV0xZPaspT+4CQDAupoR+0NbNdYxW8KfJsmy1FP5Wi7cAoBVUNLWX5/ne2G83gj9FafesEvUD9J4qmt8bm23zIRD8a8iybK4U/mXEH6AXXJRtVvZSWzw8FRD8GpTiv1xu0doyA0BjzkqRP0DkbwbBb0g52bswtfEAAGgPCfxxtY118tUKgh+AspXD3NTGQwDAH4n7abUNsdVB2yD4kSgngL8sHwJ3p346soEACk7Kn89LUa9+PmOiNQ4IPgDASLjFFw0AMA4QfACAkYDgAwCMBAQfAGAkIPgAACMBwQcAGAkIPgDASEDwAQBGAoIPADAGnHP/B0PvDiJGlrI0AAAAAElFTkSuQmCC
@@ -843,19 +843,19 @@ spec:
                       - name: ENABLE_CONVERSION_WEBHOOK
                         value: 'true'
                       - name: RELATED_IMAGE_ARGOCD_DEX_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:19bd8a22a9877e1527f8e1ba59d9682aaea3f9b2b7cb4959b4be3f956e19716b
+                        value: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:d569fb8fe9980c62987b29693cb3cc208afdd752281ae615eaf0777067d7a4b6
                       - name: ARGOCD_DEX_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:19bd8a22a9877e1527f8e1ba59d9682aaea3f9b2b7cb4959b4be3f956e19716b
+                        value: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:d569fb8fe9980c62987b29693cb3cc208afdd752281ae615eaf0777067d7a4b6
                       - name: RELATED_IMAGE_BACKEND_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:b99249048d27ba66aeda10386226569f125b88dae577505a474b1b861fe6e3ec
+                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:cd5df7f85d3ec581c69f8640f143012313d1ea8055c9af42e40a38d9c357e248
                       - name: BACKEND_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:b99249048d27ba66aeda10386226569f125b88dae577505a474b1b861fe6e3ec
+                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:cd5df7f85d3ec581c69f8640f143012313d1ea8055c9af42e40a38d9c357e248
                       - name: RELATED_IMAGE_ARGOCD_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:cf3031bb2ed6b19384e996afe598a002893fd70ac0ce14491ff868069c53fc84
+                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:62a2577609912b37a2a85729f442eb6ccf12a94a7a9e9602a3ef6934b1b8478e
                       - name: ARGOCD_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:cf3031bb2ed6b19384e996afe598a002893fd70ac0ce14491ff868069c53fc84
+                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:62a2577609912b37a2a85729f442eb6ccf12a94a7a9e9602a3ef6934b1b8478e
                       - name: ARGOCD_REPOSERVER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:cf3031bb2ed6b19384e996afe598a002893fd70ac0ce14491ff868069c53fc84
+                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:62a2577609912b37a2a85729f442eb6ccf12a94a7a9e9602a3ef6934b1b8478e
                       - name: RELATED_IMAGE_ARGOCD_REDIS_IMAGE
                         value: registry.redhat.io/rhel9/redis-7@sha256:3d31c0cfaf4219f5bd1c52882b603215d1cb4aaef5b8d1a128d0174e090f96f3
                       - name: ARGOCD_REDIS_IMAGE
@@ -863,38 +863,38 @@ spec:
                       - name: ARGOCD_REDIS_HA_IMAGE
                         value: registry.redhat.io/rhel9/redis-7@sha256:3d31c0cfaf4219f5bd1c52882b603215d1cb4aaef5b8d1a128d0174e090f96f3
                       - name: RELATED_IMAGE_ARGOCD_REDIS_HA_PROXY_IMAGE
-                        value: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:f83f1a5094075596f1b02cc8d99baa44be80f69f58864e925ede0b4f63f94fe3
+                        value: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:e65c2e85e9aeba1984744498c0fe6e495a63f0cd5a641b57cca427095b5721fc
                       - name: ARGOCD_REDIS_HA_PROXY_IMAGE
-                        value: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:f83f1a5094075596f1b02cc8d99baa44be80f69f58864e925ede0b4f63f94fe3
+                        value: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:e65c2e85e9aeba1984744498c0fe6e495a63f0cd5a641b57cca427095b5721fc
                       - name: RELATED_IMAGE_GITOPS_CONSOLE_PLUGIN_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:2b96f4a736457f646c6adc457f5679cf2143982dab6929bf695c6e55e40b5461
+                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:cc578699da9983a7865e69a034578179a53138999b87a7fc4232d45e1fa47782
                       - name: GITOPS_CONSOLE_PLUGIN_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:2b96f4a736457f646c6adc457f5679cf2143982dab6929bf695c6e55e40b5461
+                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:cc578699da9983a7865e69a034578179a53138999b87a7fc4232d45e1fa47782
                       - name: RELATED_IMAGE_ARGOCD_EXTENSION_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:6280c601c0ddf094c05e6a66163096af7dd20e0800f80ed25ac6c0d93a33fafd
+                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:30ad8f4275cfee619bded1018140a5c482f83f623b4cc94a7b9dde7ca7ced508
                       - name: ARGOCD_EXTENSION_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:6280c601c0ddf094c05e6a66163096af7dd20e0800f80ed25ac6c0d93a33fafd
+                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:30ad8f4275cfee619bded1018140a5c482f83f623b4cc94a7b9dde7ca7ced508
                       - name: RELATED_IMAGE_ARGO_ROLLOUTS_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:8e8cc0a8ce7d6225374a718b8507e128d78338b5f3db25c741bef7da4a03afcf
+                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:887a43d80feb6b597c9e9031d3afe47839073b83b0aa0af21dfdf3cb7568d3ef
                       - name: ARGO_ROLLOUTS_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:8e8cc0a8ce7d6225374a718b8507e128d78338b5f3db25c741bef7da4a03afcf
+                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:887a43d80feb6b597c9e9031d3afe47839073b83b0aa0af21dfdf3cb7568d3ef
                       - name: RELATED_IMAGE_MUST_GATHER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:9c27f8c025b8cb7e22f33537449773286d97c5475d31cefca8559c04a4249c43
+                        value: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:e43afd4abc0e799d090eb5e5162472013a265f1aaa523adcbfce052452d1087a
                       - name: RELATED_IMAGE_KUBE_RBAC_PROXY_IMAGE
-                        value: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:b473bb5efee9fb78c1e654ef94da9213e29a8eccfda2e8359b7c1b6b4049b554
+                        value: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:73ef841545cc3eea70c00ec70ce6ee5e092ff77631d551d22e8524b2bb9f96b7
                       - name: ARGOCD_PRINCIPAL_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:6a9128c0407b2d126f2d6aa9ea4854b7ff345fb11099bdb9633cf0686b8060d2
+                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:878b54e31e8de894f42ff2d303a1f61d0b3c28f8653be3de17c8aca737a354a1
                       - name: RELATED_IMAGE_ARGOCD_PRINCIPAL_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:6a9128c0407b2d126f2d6aa9ea4854b7ff345fb11099bdb9633cf0686b8060d2
+                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:878b54e31e8de894f42ff2d303a1f61d0b3c28f8653be3de17c8aca737a354a1
                       - name: ARGOCD_AGENT_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:6a9128c0407b2d126f2d6aa9ea4854b7ff345fb11099bdb9633cf0686b8060d2
+                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:878b54e31e8de894f42ff2d303a1f61d0b3c28f8653be3de17c8aca737a354a1
                       - name: RELATED_IMAGE_ARGOCD_AGENT_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:6a9128c0407b2d126f2d6aa9ea4854b7ff345fb11099bdb9633cf0686b8060d2
+                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:878b54e31e8de894f42ff2d303a1f61d0b3c28f8653be3de17c8aca737a354a1
                       - name: ARGOCD_IMAGE_UPDATER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:c5057bf64edd2461e10aeb8ad71fa12f31d375baabf3ee3fba117a4fc22d91ff
+                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:3955440de2cb0dac18da70f662fbd134ab9b8f3a4fd2a075805d07a14cbb3a01
                       - name: RELATED_IMAGE_ARGOCD_IMAGE_UPDATER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:c5057bf64edd2461e10aeb8ad71fa12f31d375baabf3ee3fba117a4fc22d91ff
-                    image: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:73b844f2dd5f2e2749c66024801ed59539aa363aa18052018b8b80ede0ea544e
+                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:3955440de2cb0dac18da70f662fbd134ab9b8f3a4fd2a075805d07a14cbb3a01
+                    image: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:655da6cbef2269018f4adea617c26c10c6c437bd7de560909d452ca7da4f6068
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -928,7 +928,7 @@ spec:
                       - --logtostderr=true
                       - --allow-paths=/metrics
                       - --http2-disable
-                    image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:b473bb5efee9fb78c1e654ef94da9213e29a8eccfda2e8359b7c1b6b4049b554
+                    image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:73ef841545cc3eea70c00ec70ce6ee5e092ff77631d551d22e8524b2bb9f96b7
                     name: kube-rbac-proxy
                     ports:
                       - containerPort: 8443
@@ -1012,8 +1012,8 @@ spec:
   maturity: GA
   provider:
     name: Red Hat Inc
-  replaces: "openshift-gitops-operator.v1.20.2"
-  version: 1.20.3
+  replaces: "openshift-gitops-operator.v1.20.3"
+  version: 1.20.4
   webhookdefinitions:
     - admissionReviewVersions:
         - v1alpha1
@@ -1029,32 +1029,32 @@ spec:
       webhookPath: /convert
   relatedImages:
     - name: manager
-      image: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:73b844f2dd5f2e2749c66024801ed59539aa363aa18052018b8b80ede0ea544e
+      image: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:655da6cbef2269018f4adea617c26c10c6c437bd7de560909d452ca7da4f6068
     - name: kube-rbac-proxy
-      image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:b473bb5efee9fb78c1e654ef94da9213e29a8eccfda2e8359b7c1b6b4049b554
+      image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:73ef841545cc3eea70c00ec70ce6ee5e092ff77631d551d22e8524b2bb9f96b7
     - name: kube_rbac_proxy_image
-      image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:b473bb5efee9fb78c1e654ef94da9213e29a8eccfda2e8359b7c1b6b4049b554
+      image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:73ef841545cc3eea70c00ec70ce6ee5e092ff77631d551d22e8524b2bb9f96b7
     - name: argocd_dex_image
-      image: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:19bd8a22a9877e1527f8e1ba59d9682aaea3f9b2b7cb4959b4be3f956e19716b
+      image: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:d569fb8fe9980c62987b29693cb3cc208afdd752281ae615eaf0777067d7a4b6
     - name: backend_image
-      image: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:b99249048d27ba66aeda10386226569f125b88dae577505a474b1b861fe6e3ec
+      image: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:cd5df7f85d3ec581c69f8640f143012313d1ea8055c9af42e40a38d9c357e248
     - name: argocd_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:cf3031bb2ed6b19384e996afe598a002893fd70ac0ce14491ff868069c53fc84
+      image: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:62a2577609912b37a2a85729f442eb6ccf12a94a7a9e9602a3ef6934b1b8478e
     - name: argocd_redis_image
       image: registry.redhat.io/rhel9/redis-7@sha256:3d31c0cfaf4219f5bd1c52882b603215d1cb4aaef5b8d1a128d0174e090f96f3
     - name: argocd_redis_ha_proxy_image
-      image: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:f83f1a5094075596f1b02cc8d99baa44be80f69f58864e925ede0b4f63f94fe3
+      image: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:e65c2e85e9aeba1984744498c0fe6e495a63f0cd5a641b57cca427095b5721fc
     - name: gitops_console_plugin_image
-      image: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:2b96f4a736457f646c6adc457f5679cf2143982dab6929bf695c6e55e40b5461
+      image: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:cc578699da9983a7865e69a034578179a53138999b87a7fc4232d45e1fa47782
     - name: argocd_extension_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:6280c601c0ddf094c05e6a66163096af7dd20e0800f80ed25ac6c0d93a33fafd
+      image: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:30ad8f4275cfee619bded1018140a5c482f83f623b4cc94a7b9dde7ca7ced508
     - name: argo_rollouts_image
-      image: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:8e8cc0a8ce7d6225374a718b8507e128d78338b5f3db25c741bef7da4a03afcf
+      image: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:887a43d80feb6b597c9e9031d3afe47839073b83b0aa0af21dfdf3cb7568d3ef
     - name: must_gather_image
-      image: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:9c27f8c025b8cb7e22f33537449773286d97c5475d31cefca8559c04a4249c43
+      image: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:e43afd4abc0e799d090eb5e5162472013a265f1aaa523adcbfce052452d1087a
     - name: argocd_principal_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:6a9128c0407b2d126f2d6aa9ea4854b7ff345fb11099bdb9633cf0686b8060d2
+      image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:878b54e31e8de894f42ff2d303a1f61d0b3c28f8653be3de17c8aca737a354a1
     - name: argocd_agent_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:6a9128c0407b2d126f2d6aa9ea4854b7ff345fb11099bdb9633cf0686b8060d2
+      image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:878b54e31e8de894f42ff2d303a1f61d0b3c28f8653be3de17c8aca737a354a1
     - name: argocd_image_updater_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:c5057bf64edd2461e10aeb8ad71fa12f31d375baabf3ee3fba117a4fc22d91ff
+      image: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:3955440de2cb0dac18da70f662fbd134ab9b8f3a4fd2a075805d07a14cbb3a01


### PR DESCRIPTION
This PR updates the bundle files with the latest image shas for release-1.20 tag.

Automatically generated from `release-1.20` branch using GitHub Actions.