### PR TITLE
chore: bumps argocd-image-updater to commit 1b622412d7ecc2392e86bd5d1d2fee755fc71ca1 (v1.2.1)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -89,8 +89,8 @@ sources:
     commit: 7bf329860e465e5138559fc1f6f79b7f7caba042
   - path: sources/argocd-image-updater
     url: https://github.com/argoproj-labs/argocd-image-updater.git
-    ref: v1.2.0
-    commit: d611926ae8558abe5aa2a93f34cc51e9e1c398ac
+    ref: v1.2.1
+    commit: 1b622412d7ecc2392e86bd5d1d2fee755fc71ca1
 
 # External images pulled directly from Red Hat registry and are
 # required by the operator at runtime.


### PR DESCRIPTION
Image Updater v1.2.1 was released https://github.com/argoproj-labs/argocd-image-updater/commit/1b622412d7ecc2392e86bd5d1d2fee755fc71ca1