### PR TITLE
chore(bundle): latest bundle updates for v1.21.0-3

### DIFF
--- a/containers/gitops-operator-bundle/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/containers/gitops-operator-bundle/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -189,7 +189,7 @@ metadata:
       ]
     capabilities: Deep Insights
     console.openshift.io/plugins: '["gitops-plugin"]'
-    containerImage: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:62efd6d91133955c5ec51a106470cafa23ece7dc0043c708399900408accc9bf
+    containerImage: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:0c353ffbceecbea391c994845fb592852c9ae07de54166195acdc7738a74ea2d
     createdAt: "2026-06-03T18:12:37Z"
     description: Enables teams to adopt GitOps principles for managing cluster configurations and application delivery across hybrid multi-cluster Kubernetes environments.
     features.operators.openshift.io/disconnected: "true"
@@ -208,7 +208,7 @@ metadata:
     support: Red Hat
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/internal-objects: '["gitopsservices.pipelines.openshift.io"]'
-    operators.openshift.io/must-gather-image: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:d2a8c6ff9fa01d3da1f1d86b090633a7ca8bdf4b4dd63e2aff02af15d11e3420
+    operators.openshift.io/must-gather-image: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:b36fcc6b21d9eea8a97fea8be828edb68716d722487ddb71933b36f80edff16f
     features.operators.openshift.io/cnf: 'false'
     features.operators.openshift.io/cni: 'false'
     features.operators.openshift.io/csi: 'false'
@@ -855,19 +855,19 @@ spec:
                       - name: ENABLE_CONVERSION_WEBHOOK
                         value: 'true'
                       - name: RELATED_IMAGE_ARGOCD_DEX_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:88ffba08863a5ef250e873a0d2dcf339bf9e964307023a160c02f18269f9dad2
+                        value: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:dca91a5d2033f29a0e0e86cc45cb19d9897537ee10dd27f074de8ea278a9f66f
                       - name: ARGOCD_DEX_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:88ffba08863a5ef250e873a0d2dcf339bf9e964307023a160c02f18269f9dad2
+                        value: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:dca91a5d2033f29a0e0e86cc45cb19d9897537ee10dd27f074de8ea278a9f66f
                       - name: RELATED_IMAGE_BACKEND_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:f88c404faabf7281c5a1ed804df0e3a390fd0274885fd240cbb7419fc0b23685
+                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:531f93e5e85485eb19c9729054af84fd76b7b38051713393c30ef5e197b18dde
                       - name: BACKEND_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:f88c404faabf7281c5a1ed804df0e3a390fd0274885fd240cbb7419fc0b23685
+                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:531f93e5e85485eb19c9729054af84fd76b7b38051713393c30ef5e197b18dde
                       - name: RELATED_IMAGE_ARGOCD_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:f03ed39e709124b5f2b5f394cff94465d39dc69610e1b798fe6c5d2c53ca3630
+                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:d8c711910b6fa21d36b56299d80276017f4f91d26592ac4f8da195c91e33c909
                       - name: ARGOCD_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:f03ed39e709124b5f2b5f394cff94465d39dc69610e1b798fe6c5d2c53ca3630
+                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:d8c711910b6fa21d36b56299d80276017f4f91d26592ac4f8da195c91e33c909
                       - name: ARGOCD_REPOSERVER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:f03ed39e709124b5f2b5f394cff94465d39dc69610e1b798fe6c5d2c53ca3630
+                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:d8c711910b6fa21d36b56299d80276017f4f91d26592ac4f8da195c91e33c909
                       - name: RELATED_IMAGE_ARGOCD_REDIS_IMAGE
                         value: registry.redhat.io/rhel9/redis-7@sha256:3d31c0cfaf4219f5bd1c52882b603215d1cb4aaef5b8d1a128d0174e090f96f3
                       - name: ARGOCD_REDIS_IMAGE
@@ -879,32 +879,32 @@ spec:
                       - name: ARGOCD_REDIS_HA_PROXY_IMAGE
                         value: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:3736c22cb53b0fcc7ad1b34a8ba83f94445ac5f7008b29f9b5c42381178c4996
                       - name: RELATED_IMAGE_GITOPS_CONSOLE_PLUGIN_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:750ecf6b7ead5668fb4f649ff8b2177ae7e7c0dbbaf63cfb429301303ddbe325
+                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:63d885d322f45c6cce7fdb2d225487e277f00db7c25ecaa3eb83935f6e414ad1
                       - name: GITOPS_CONSOLE_PLUGIN_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:750ecf6b7ead5668fb4f649ff8b2177ae7e7c0dbbaf63cfb429301303ddbe325
+                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:63d885d322f45c6cce7fdb2d225487e277f00db7c25ecaa3eb83935f6e414ad1
                       - name: RELATED_IMAGE_ARGOCD_EXTENSION_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:a53d8b8e46bb1c3908beb98419e3c3ecf287a3609d96af8d385929a5ce95ddc0
+                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:44bcbab027ff294515b0925e6a0848eca3fd92f001c4a906508ae31819112fe8
                       - name: ARGOCD_EXTENSION_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:a53d8b8e46bb1c3908beb98419e3c3ecf287a3609d96af8d385929a5ce95ddc0
+                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:44bcbab027ff294515b0925e6a0848eca3fd92f001c4a906508ae31819112fe8
                       - name: RELATED_IMAGE_ARGO_ROLLOUTS_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:22accc34827be3cbf291b35896e1ddc85c5da5c15f2237a216f9bfa9e1c606e7
+                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:a2ac38c1fa2cbcc5be52de67f96f49cd868efb7b6e8d19bcf8ddabc80af578e4
                       - name: ARGO_ROLLOUTS_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:22accc34827be3cbf291b35896e1ddc85c5da5c15f2237a216f9bfa9e1c606e7
+                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:a2ac38c1fa2cbcc5be52de67f96f49cd868efb7b6e8d19bcf8ddabc80af578e4
                       - name: RELATED_IMAGE_MUST_GATHER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:d2a8c6ff9fa01d3da1f1d86b090633a7ca8bdf4b4dd63e2aff02af15d11e3420
+                        value: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:b36fcc6b21d9eea8a97fea8be828edb68716d722487ddb71933b36f80edff16f
                       - name: ARGOCD_PRINCIPAL_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:a1f019d71add1bddd6efea60033b0bb185689ef347ab14b6738efc7f71d41684
+                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:15c8e6248548888877d608f903efd7f62ef07ed7e79da5e8f3921b20a22c6482
                       - name: RELATED_IMAGE_ARGOCD_PRINCIPAL_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:a1f019d71add1bddd6efea60033b0bb185689ef347ab14b6738efc7f71d41684
+                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:15c8e6248548888877d608f903efd7f62ef07ed7e79da5e8f3921b20a22c6482
                       - name: ARGOCD_AGENT_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:a1f019d71add1bddd6efea60033b0bb185689ef347ab14b6738efc7f71d41684
+                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:15c8e6248548888877d608f903efd7f62ef07ed7e79da5e8f3921b20a22c6482
                       - name: RELATED_IMAGE_ARGOCD_AGENT_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:a1f019d71add1bddd6efea60033b0bb185689ef347ab14b6738efc7f71d41684
+                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:15c8e6248548888877d608f903efd7f62ef07ed7e79da5e8f3921b20a22c6482
                       - name: ARGOCD_IMAGE_UPDATER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:684529551509112d5974454862efa93c89b3c13e2991faae8e8ecfe5ad7acfe3
+                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:979fbf22e72c71e59803f57e05042efd76b847353062765a4156362f4b42f12d
                       - name: RELATED_IMAGE_ARGOCD_IMAGE_UPDATER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:684529551509112d5974454862efa93c89b3c13e2991faae8e8ecfe5ad7acfe3
-                    image: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:62efd6d91133955c5ec51a106470cafa23ece7dc0043c708399900408accc9bf
+                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:979fbf22e72c71e59803f57e05042efd76b847353062765a4156362f4b42f12d
+                    image: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:0c353ffbceecbea391c994845fb592852c9ae07de54166195acdc7738a74ea2d
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -1011,28 +1011,28 @@ spec:
       webhookPath: /convert
   relatedImages:
     - name: manager
-      image: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:62efd6d91133955c5ec51a106470cafa23ece7dc0043c708399900408accc9bf
+      image: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:0c353ffbceecbea391c994845fb592852c9ae07de54166195acdc7738a74ea2d
     - name: argocd_dex_image
-      image: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:88ffba08863a5ef250e873a0d2dcf339bf9e964307023a160c02f18269f9dad2
+      image: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:dca91a5d2033f29a0e0e86cc45cb19d9897537ee10dd27f074de8ea278a9f66f
     - name: backend_image
-      image: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:f88c404faabf7281c5a1ed804df0e3a390fd0274885fd240cbb7419fc0b23685
+      image: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:531f93e5e85485eb19c9729054af84fd76b7b38051713393c30ef5e197b18dde
     - name: argocd_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:f03ed39e709124b5f2b5f394cff94465d39dc69610e1b798fe6c5d2c53ca3630
+      image: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:d8c711910b6fa21d36b56299d80276017f4f91d26592ac4f8da195c91e33c909
     - name: argocd_redis_image
       image: registry.redhat.io/rhel9/redis-7@sha256:3d31c0cfaf4219f5bd1c52882b603215d1cb4aaef5b8d1a128d0174e090f96f3
     - name: argocd_redis_ha_proxy_image
       image: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:3736c22cb53b0fcc7ad1b34a8ba83f94445ac5f7008b29f9b5c42381178c4996
     - name: gitops_console_plugin_image
-      image: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:750ecf6b7ead5668fb4f649ff8b2177ae7e7c0dbbaf63cfb429301303ddbe325
+      image: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:63d885d322f45c6cce7fdb2d225487e277f00db7c25ecaa3eb83935f6e414ad1
     - name: argocd_extension_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:a53d8b8e46bb1c3908beb98419e3c3ecf287a3609d96af8d385929a5ce95ddc0
+      image: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:44bcbab027ff294515b0925e6a0848eca3fd92f001c4a906508ae31819112fe8
     - name: argo_rollouts_image
-      image: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:22accc34827be3cbf291b35896e1ddc85c5da5c15f2237a216f9bfa9e1c606e7
+      image: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:a2ac38c1fa2cbcc5be52de67f96f49cd868efb7b6e8d19bcf8ddabc80af578e4
     - name: must_gather_image
-      image: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:d2a8c6ff9fa01d3da1f1d86b090633a7ca8bdf4b4dd63e2aff02af15d11e3420
+      image: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:b36fcc6b21d9eea8a97fea8be828edb68716d722487ddb71933b36f80edff16f
     - name: argocd_principal_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:a1f019d71add1bddd6efea60033b0bb185689ef347ab14b6738efc7f71d41684
+      image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:15c8e6248548888877d608f903efd7f62ef07ed7e79da5e8f3921b20a22c6482
     - name: argocd_agent_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:a1f019d71add1bddd6efea60033b0bb185689ef347ab14b6738efc7f71d41684
+      image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:15c8e6248548888877d608f903efd7f62ef07ed7e79da5e8f3921b20a22c6482
     - name: argocd_image_updater_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:684529551509112d5974454862efa93c89b3c13e2991faae8e8ecfe5ad7acfe3
+      image: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:979fbf22e72c71e59803f57e05042efd76b847353062765a4156362f4b42f12d


### PR DESCRIPTION
This PR updates the bundle files with the latest image shas for release-1.21 tag.

Automatically generated from `release-1.21` branch using GitHub Actions.