### PR TITLE
chore(bundle): latest bundle updates for v1.21.0-5

### DIFF
--- a/containers/gitops-operator-bundle/bundle/manifests/argocd-image-updater.argoproj.io_imageupdaters.yaml
+++ b/containers/gitops-operator-bundle/bundle/manifests/argocd-image-updater.argoproj.io_imageupdaters.yaml
@@ -14,7 +14,20 @@ spec:
     singular: imageupdater
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.applicationsMatched
+      name: Apps
+      type: integer
+    - jsonPath: .status.imagesManaged
+      name: Images
+      type: integer
+    - jsonPath: .status.lastCheckedAt
+      name: Last Checked
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ImageUpdater is the Schema for the imageupdaters API
@@ -306,6 +319,25 @@ spec:
                                 Branch to commit updates to.
                                 Required if write-back method is Git and this is not specified at the spec level.
                               type: string
+                            pullRequest:
+                              description: |-
+                                PullRequest configures creation of pull requests when writing back image updates to Git.
+                                When set, the controller opens a PR instead of pushing to the branch.
+                                If not specified write back config method is `git`.
+                              properties:
+                                github:
+                                  description: GitHub configures PR creation via the
+                                    GitHub API.
+                                  type: object
+                                gitlab:
+                                  description: GitLab configures MR creation via the
+                                    GitLab API.
+                                  type: object
+                              type: object
+                              x-kubernetes-validations:
+                              - message: Exactly one of github or gitlab must be set
+                                rule: '(has(self.github) ? 1 : 0) + (has(self.gitlab)
+                                  ? 1 : 0) == 1'
                             repository:
                               description: |-
                                 Repository URL to commit changes to.
@@ -390,14 +422,6 @@ spec:
                       This acts as the default if not overridden at a more specific level.
                     type: string
                 type: object
-              namespace:
-                description: |-
-                  Namespace indicates the target namespace of the applications.
-
-                  Deprecated: This field is deprecated and will be removed in a future release.
-                  The controller now uses the ImageUpdater CR's namespace (metadata.namespace)
-                  to determine which namespace to search for applications. This field is ignored.
-                type: string
               writeBackConfig:
                 description: |-
                   WriteBackConfig provides global default settings for how and where to write back image updates.
@@ -413,6 +437,25 @@ spec:
                           Branch to commit updates to.
                           Required if write-back method is Git and this is not specified at the spec level.
                         type: string
+                      pullRequest:
+                        description: |-
+                          PullRequest configures creation of pull requests when writing back image updates to Git.
+                          When set, the controller opens a PR instead of pushing to the branch.
+                          If not specified write back config method is `git`.
+                        properties:
+                          github:
+                            description: GitHub configures PR creation via the GitHub
+                              API.
+                            type: object
+                          gitlab:
+                            description: GitLab configures MR creation via the GitLab
+                              API.
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Exactly one of github or gitlab must be set
+                          rule: '(has(self.github) ? 1 : 0) + (has(self.gitlab) ?
+                            1 : 0) == 1'
                       repository:
                         description: |-
                           Repository URL to commit changes to.
@@ -444,7 +487,15 @@ spec:
           status:
             description: ImageUpdaterStatus defines the observed state of ImageUpdater
             properties:
+              applicationsMatched:
+                description: ApplicationsMatched is the number of Argo CD applications
+                  matched by this CR's selectors.
+                format: int32
+                minimum: 0
+                type: integer
               conditions:
+                description: Conditions represent the latest available observations
+                  of the resource's state.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -500,48 +551,73 @@ spec:
                   - type
                   type: object
                 type: array
-              imageStatus:
-                description: ImageStatus indicates the detailed status for the list
-                  of managed images
-                items:
-                  description: ImageStatus contains information for an image:version
-                    and its update status in hosting applications
-                  properties:
-                    applications:
-                      description: Applications contains a list of applications and
-                        when the image was last updated therein
-                      items:
-                        description: ImageApplicationLastUpdated contains information
-                          for an application and when the image was last updated therein
-                        properties:
-                          appName:
-                            description: AppName indicates and namespace and the application
-                              name
-                            type: string
-                          lastUpdatedAt:
-                            description: LastUpdatedAt indicates when the image in
-                              this application was last updated
-                            format: date-time
-                            type: string
-                        required:
-                        - appName
-                        type: object
-                      type: array
-                    name:
-                      description: Name indicates the image name
-                      type: string
-                    version:
-                      description: Version indicates the image version
-                      type: string
-                  required:
-                  - name
-                  - version
-                  type: object
-                type: array
-              reconciledAt:
-                description: LastUpdatedAt indicates when the image updater last ran
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              imagesManaged:
+                description: ImagesManaged is the number of images that were eligible
+                  for update checking.
+                format: int32
+                minimum: 0
+                type: integer
+              lastCheckedAt:
+                description: LastCheckedAt indicates when the controller last checked
+                  for image updates.
                 format: date-time
                 type: string
+              lastUpdatedAt:
+                description: LastUpdatedAt indicates when the controller last performed
+                  an image update.
+                format: date-time
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                minimum: 0
+                type: integer
+              recentUpdates:
+                description: RecentUpdates contains the list of image updates performed
+                  during the last update cycle.
+                items:
+                  description: RecentUpdate records a single image update performed
+                    during the last update.
+                  properties:
+                    alias:
+                      description: Alias is the alias of the image configuration that
+                        was updated.
+                      type: string
+                    applicationsUpdated:
+                      description: ApplicationsUpdated is the number of applications
+                        in which this image was updated.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    image:
+                      description: Image is the full image reference.
+                      type: string
+                    message:
+                      description: Message provides a human-readable description of
+                        the update action.
+                      type: string
+                    newVersion:
+                      description: NewVersion is the new tag or digest the image was
+                        updated to.
+                      type: string
+                    updatedAt:
+                      description: UpdatedAt is the timestamp when the update was
+                        applied.
+                      format: date-time
+                      type: string
+                  required:
+                  - alias
+                  - applicationsUpdated
+                  - image
+                  - newVersion
+                  - updatedAt
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
             type: object
         type: object
     served: true

--- a/containers/gitops-operator-bundle/bundle/manifests/argoproj.io_applications.yaml
+++ b/containers/gitops-operator-bundle/bundle/manifests/argoproj.io_applications.yaml
@@ -411,12 +411,12 @@ spec:
                               apply common labels to resource selectors or not
                             type: boolean
                           namePrefix:
-                            description: NamePrefix is a prefix appended to resources
-                              for Kustomize apps
+                            description: NamePrefix overrides the namePrefix in the
+                              kustomization.yaml for Kustomize apps
                             type: string
                           nameSuffix:
-                            description: NameSuffix is a suffix appended to resources
-                              for Kustomize apps
+                            description: NameSuffix overrides the nameSuffix in the
+                              kustomization.yaml for Kustomize apps
                             type: string
                           namespace:
                             description: Namespace sets the namespace that Kustomize
@@ -800,12 +800,12 @@ spec:
                                 to apply common labels to resource selectors or not
                               type: boolean
                             namePrefix:
-                              description: NamePrefix is a prefix appended to resources
-                                for Kustomize apps
+                              description: NamePrefix overrides the namePrefix in
+                                the kustomization.yaml for Kustomize apps
                               type: string
                             nameSuffix:
-                              description: NameSuffix is a suffix appended to resources
-                                for Kustomize apps
+                              description: NameSuffix overrides the nameSuffix in
+                                the kustomization.yaml for Kustomize apps
                               type: string
                             namespace:
                               description: Namespace sets the namespace that Kustomize
@@ -1299,11 +1299,11 @@ spec:
                           common labels to resource selectors or not
                         type: boolean
                       namePrefix:
-                        description: NamePrefix is a prefix appended to resources
+                        description: NamePrefix overrides the namePrefix in the kustomization.yaml
                           for Kustomize apps
                         type: string
                       nameSuffix:
-                        description: NameSuffix is a suffix appended to resources
+                        description: NameSuffix overrides the nameSuffix in the kustomization.yaml
                           for Kustomize apps
                         type: string
                       namespace:
@@ -1676,12 +1676,12 @@ spec:
                               apply common labels to resource selectors or not
                             type: boolean
                           namePrefix:
-                            description: NamePrefix is a prefix appended to resources
-                              for Kustomize apps
+                            description: NamePrefix overrides the namePrefix in the
+                              kustomization.yaml for Kustomize apps
                             type: string
                           nameSuffix:
-                            description: NameSuffix is a suffix appended to resources
-                              for Kustomize apps
+                            description: NameSuffix overrides the nameSuffix in the
+                              kustomization.yaml for Kustomize apps
                             type: string
                           namespace:
                             description: Namespace sets the namespace that Kustomize
@@ -2087,12 +2087,12 @@ spec:
                             common labels to resource selectors or not
                           type: boolean
                         namePrefix:
-                          description: NamePrefix is a prefix appended to resources
-                            for Kustomize apps
+                          description: NamePrefix overrides the namePrefix in the
+                            kustomization.yaml for Kustomize apps
                           type: string
                         nameSuffix:
-                          description: NameSuffix is a suffix appended to resources
-                            for Kustomize apps
+                          description: NameSuffix overrides the nameSuffix in the
+                            kustomization.yaml for Kustomize apps
                           type: string
                         namespace:
                           description: Namespace sets the namespace that Kustomize
@@ -2646,12 +2646,12 @@ spec:
                                 to apply common labels to resource selectors or not
                               type: boolean
                             namePrefix:
-                              description: NamePrefix is a prefix appended to resources
-                                for Kustomize apps
+                              description: NamePrefix overrides the namePrefix in
+                                the kustomization.yaml for Kustomize apps
                               type: string
                             nameSuffix:
-                              description: NameSuffix is a suffix appended to resources
-                                for Kustomize apps
+                              description: NameSuffix overrides the nameSuffix in
+                                the kustomization.yaml for Kustomize apps
                               type: string
                             namespace:
                               description: Namespace sets the namespace that Kustomize
@@ -3039,12 +3039,12 @@ spec:
                                   not
                                 type: boolean
                               namePrefix:
-                                description: NamePrefix is a prefix appended to resources
-                                  for Kustomize apps
+                                description: NamePrefix overrides the namePrefix in
+                                  the kustomization.yaml for Kustomize apps
                                 type: string
                               nameSuffix:
-                                description: NameSuffix is a suffix appended to resources
-                                  for Kustomize apps
+                                description: NameSuffix overrides the nameSuffix in
+                                  the kustomization.yaml for Kustomize apps
                                 type: string
                               namespace:
                                 description: Namespace sets the namespace that Kustomize
@@ -3191,6 +3191,7 @@ spec:
               observedAt:
                 description: |-
                   ObservedAt indicates when the application state was updated without querying latest git state
+
                   Deprecated: controller no longer updates ObservedAt field
                 format: date-time
                 type: string
@@ -3587,12 +3588,12 @@ spec:
                                       or not
                                     type: boolean
                                   namePrefix:
-                                    description: NamePrefix is a prefix appended to
-                                      resources for Kustomize apps
+                                    description: NamePrefix overrides the namePrefix
+                                      in the kustomization.yaml for Kustomize apps
                                     type: string
                                   nameSuffix:
-                                    description: NameSuffix is a suffix appended to
-                                      resources for Kustomize apps
+                                    description: NameSuffix overrides the nameSuffix
+                                      in the kustomization.yaml for Kustomize apps
                                     type: string
                                   namespace:
                                     description: Namespace sets the namespace that
@@ -4000,12 +4001,12 @@ spec:
                                         selectors or not
                                       type: boolean
                                     namePrefix:
-                                      description: NamePrefix is a prefix appended
-                                        to resources for Kustomize apps
+                                      description: NamePrefix overrides the namePrefix
+                                        in the kustomization.yaml for Kustomize apps
                                       type: string
                                     nameSuffix:
-                                      description: NameSuffix is a suffix appended
-                                        to resources for Kustomize apps
+                                      description: NameSuffix overrides the nameSuffix
+                                        in the kustomization.yaml for Kustomize apps
                                       type: string
                                     namespace:
                                       description: Namespace sets the namespace that
@@ -4530,12 +4531,12 @@ spec:
                                   not
                                 type: boolean
                               namePrefix:
-                                description: NamePrefix is a prefix appended to resources
-                                  for Kustomize apps
+                                description: NamePrefix overrides the namePrefix in
+                                  the kustomization.yaml for Kustomize apps
                                 type: string
                               nameSuffix:
-                                description: NameSuffix is a suffix appended to resources
-                                  for Kustomize apps
+                                description: NameSuffix overrides the nameSuffix in
+                                  the kustomization.yaml for Kustomize apps
                                 type: string
                               namespace:
                                 description: Namespace sets the namespace that Kustomize
@@ -4934,12 +4935,12 @@ spec:
                                     not
                                   type: boolean
                                 namePrefix:
-                                  description: NamePrefix is a prefix appended to
-                                    resources for Kustomize apps
+                                  description: NamePrefix overrides the namePrefix
+                                    in the kustomization.yaml for Kustomize apps
                                   type: string
                                 nameSuffix:
-                                  description: NameSuffix is a suffix appended to
-                                    resources for Kustomize apps
+                                  description: NameSuffix overrides the nameSuffix
+                                    in the kustomization.yaml for Kustomize apps
                                   type: string
                                 namespace:
                                   description: Namespace sets the namespace that Kustomize
@@ -5459,12 +5460,12 @@ spec:
                                       or not
                                     type: boolean
                                   namePrefix:
-                                    description: NamePrefix is a prefix appended to
-                                      resources for Kustomize apps
+                                    description: NamePrefix overrides the namePrefix
+                                      in the kustomization.yaml for Kustomize apps
                                     type: string
                                   nameSuffix:
-                                    description: NameSuffix is a suffix appended to
-                                      resources for Kustomize apps
+                                    description: NameSuffix overrides the nameSuffix
+                                      in the kustomization.yaml for Kustomize apps
                                     type: string
                                   namespace:
                                     description: Namespace sets the namespace that
@@ -5912,12 +5913,12 @@ spec:
                                       or not
                                     type: boolean
                                   namePrefix:
-                                    description: NamePrefix is a prefix appended to
-                                      resources for Kustomize apps
+                                    description: NamePrefix overrides the namePrefix
+                                      in the kustomization.yaml for Kustomize apps
                                     type: string
                                   nameSuffix:
-                                    description: NameSuffix is a suffix appended to
-                                      resources for Kustomize apps
+                                    description: NameSuffix overrides the nameSuffix
+                                      in the kustomization.yaml for Kustomize apps
                                     type: string
                                   namespace:
                                     description: Namespace sets the namespace that
@@ -6425,12 +6426,12 @@ spec:
                                   not
                                 type: boolean
                               namePrefix:
-                                description: NamePrefix is a prefix appended to resources
-                                  for Kustomize apps
+                                description: NamePrefix overrides the namePrefix in
+                                  the kustomization.yaml for Kustomize apps
                                 type: string
                               nameSuffix:
-                                description: NameSuffix is a suffix appended to resources
-                                  for Kustomize apps
+                                description: NameSuffix overrides the nameSuffix in
+                                  the kustomization.yaml for Kustomize apps
                                 type: string
                               namespace:
                                 description: Namespace sets the namespace that Kustomize
@@ -6829,12 +6830,12 @@ spec:
                                     not
                                   type: boolean
                                 namePrefix:
-                                  description: NamePrefix is a prefix appended to
-                                    resources for Kustomize apps
+                                  description: NamePrefix overrides the namePrefix
+                                    in the kustomization.yaml for Kustomize apps
                                   type: string
                                 nameSuffix:
-                                  description: NameSuffix is a suffix appended to
-                                    resources for Kustomize apps
+                                  description: NameSuffix overrides the nameSuffix
+                                    in the kustomization.yaml for Kustomize apps
                                   type: string
                                 namespace:
                                   description: Namespace sets the namespace that Kustomize

--- a/containers/gitops-operator-bundle/bundle/manifests/argoproj.io_applicationsets.yaml
+++ b/containers/gitops-operator-bundle/bundle/manifests/argoproj.io_applicationsets.yaml
@@ -23116,6 +23116,16 @@ spec:
                   - type
                   type: object
                 type: array
+              health:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  status:
+                    type: string
+                type: object
               resources:
                 items:
                   properties:

--- a/containers/gitops-operator-bundle/bundle/manifests/argoproj.io_argocds.yaml
+++ b/containers/gitops-operator-bundle/bundle/manifests/argoproj.io_argocds.yaml
@@ -699,6 +699,21 @@ spec:
                         description: LogLevel refers to the log level used by the
                           Agent component.
                         type: string
+                      metrics:
+                        description: Metrics defines the metrics configuration for
+                          the Agent ServiceMonitor.
+                        properties:
+                          interval:
+                            description: |-
+                              Interval specifies the Prometheus scrape interval for this component's ServiceMonitor.
+                              If empty, Prometheus uses its default scrape interval.
+                            type: string
+                          scrapeTimeout:
+                            description: |-
+                              ScrapeTimeout specifies the Prometheus scrape timeout for this component's ServiceMonitor.
+                              If empty, Prometheus uses the global scrape timeout.
+                            type: string
+                        type: object
                       redis:
                         description: Redis defines the Redis options for the Agent
                           component.
@@ -922,6 +937,21 @@ spec:
                         description: LogLevel refers to the log level used by the
                           Principal component.
                         type: string
+                      metrics:
+                        description: Metrics defines the metrics configuration for
+                          the Principal ServiceMonitor.
+                        properties:
+                          interval:
+                            description: |-
+                              Interval specifies the Prometheus scrape interval for this component's ServiceMonitor.
+                              If empty, Prometheus uses its default scrape interval.
+                            type: string
+                          scrapeTimeout:
+                            description: |-
+                              ScrapeTimeout specifies the Prometheus scrape timeout for this component's ServiceMonitor.
+                              If empty, Prometheus uses the global scrape timeout.
+                            type: string
+                        type: object
                       namespace:
                         description: Namespace is the configuration for the Principal
                           component namespace.
@@ -1242,6 +1272,21 @@ spec:
                       Controller component. Defaults to ArgoCDDefaultLogLevel if not
                       configured. Valid options are debug, info, error, and warn.
                     type: string
+                  metrics:
+                    description: Metrics defines the metrics configuration for the
+                      Application Controller ServiceMonitor.
+                    properties:
+                      interval:
+                        description: |-
+                          Interval specifies the Prometheus scrape interval for this component's ServiceMonitor.
+                          If empty, Prometheus uses its default scrape interval.
+                        type: string
+                      scrapeTimeout:
+                        description: |-
+                          ScrapeTimeout specifies the Prometheus scrape timeout for this component's ServiceMonitor.
+                          If empty, Prometheus uses the global scrape timeout.
+                        type: string
+                    type: object
                   parallelismLimit:
                     description: ParallelismLimit defines the limit for parallel kubectl
                       operations
@@ -1325,6 +1370,15 @@ spec:
                     description: Sharding contains the options for the Application
                       Controller sharding configuration.
                     properties:
+                      algorithm:
+                        description: DistributionAlgorithm determines what algorithm
+                          will be used for distribution of shards. Valid options are
+                          legacy, round-robin, and consistent-hashing
+                        enum:
+                        - legacy
+                        - round-robin
+                        - consistent-hashing
+                        type: string
                       clustersPerShard:
                         description: ClustersPerShard defines the maximum number of
                           clusters managed by each argocd shard
@@ -1905,7 +1959,6 @@ spec:
                   NetworkPolicy resources for this Argo CD instance.
                 properties:
                   enabled:
-                    default: true
                     description: |-
                       Enabled defines whether NetworkPolicy resources should be created for this Argo CD instance.
                       When enabled, the operator will reconcile NetworkPolicies for Argo CD components.
@@ -2133,12 +2186,7 @@ spec:
                   image:
                     description: Image is the Argo CD Notifications image (optional)
                     type: string
-                  logLevel:
-                    description: LogLevel describes the log level that should be used
-                      by the argocd-notifications. Defaults to ArgoCDDefaultLogLevel
-                      if not set.  Valid options are debug,info, error, and warn.
-                    type: string
-                  logformat:
+                  logFormat:
                     description: LogFormat refers to the log format used by the argocd-notifications.
                       Defaults to ArgoCDDefaultLogFormat if not configured. Valid
                       options are text or json.
@@ -2146,6 +2194,29 @@ spec:
                     - text
                     - json
                     type: string
+                  logLevel:
+                    description: LogLevel describes the log level that should be used
+                      by the argocd-notifications. Defaults to ArgoCDDefaultLogLevel
+                      if not set.  Valid options are debug,info, error, and warn.
+                    type: string
+                  logformat:
+                    description: 'Deprecated: use LogFormat instead.'
+                    type: string
+                  metrics:
+                    description: Metrics defines the metrics configuration for the
+                      Notifications ServiceMonitor.
+                    properties:
+                      interval:
+                        description: |-
+                          Interval specifies the Prometheus scrape interval for this component's ServiceMonitor.
+                          If empty, Prometheus uses its default scrape interval.
+                        type: string
+                      scrapeTimeout:
+                        description: |-
+                          ScrapeTimeout specifies the Prometheus scrape timeout for this component's ServiceMonitor.
+                          If empty, Prometheus uses the global scrape timeout.
+                        type: string
+                    type: object
                   replicas:
                     description: Replicas defines the number of replicas to run for
                       notifications-controller
@@ -4247,6 +4318,21 @@ spec:
                       by the Repo Server. Defaults to ArgoCDDefaultLogLevel if not
                       set.  Valid options are debug, info, error, and warn.
                     type: string
+                  metrics:
+                    description: Metrics defines the metrics configuration for the
+                      Repo Server ServiceMonitor.
+                    properties:
+                      interval:
+                        description: |-
+                          Interval specifies the Prometheus scrape interval for this component's ServiceMonitor.
+                          If empty, Prometheus uses its default scrape interval.
+                        type: string
+                      scrapeTimeout:
+                        description: |-
+                          ScrapeTimeout specifies the Prometheus scrape timeout for this component's ServiceMonitor.
+                          If empty, Prometheus uses the global scrape timeout.
+                        type: string
+                    type: object
                   mountsatoken:
                     description: MountSAToken describes whether you would like to
                       have the Repo server mount the service account token
@@ -8278,6 +8364,21 @@ spec:
                       ArgoCD Server component. Defaults to ArgoCDDefaultLogLevel if
                       not set.  Valid options are debug, info, error, and warn.
                     type: string
+                  metrics:
+                    description: Metrics defines the metrics configuration for the
+                      Server ServiceMonitor.
+                    properties:
+                      interval:
+                        description: |-
+                          Interval specifies the Prometheus scrape interval for this component's ServiceMonitor.
+                          If empty, Prometheus uses its default scrape interval.
+                        type: string
+                      scrapeTimeout:
+                        description: |-
+                          ScrapeTimeout specifies the Prometheus scrape timeout for this component's ServiceMonitor.
+                          If empty, Prometheus uses the global scrape timeout.
+                        type: string
+                    type: object
                   replicas:
                     description: Replicas defines the number of replicas for argocd-server.
                       Default is nil. Value should be greater than or equal to 0.
@@ -8755,6 +8856,145 @@ spec:
                 description: Version is the tag to use with the ArgoCD container image
                   for all ArgoCD components.
                 type: string
+              webhookSecrets:
+                description: |-
+                  WebhookSecrets references Kubernetes Secrets that supply webhook credentials per provider.
+                  The operator syncs values into argocd-secret under the keys Argo CD expects.
+                properties:
+                  azureDevOps:
+                    description: 'AzureDevOps: Secret key references for the Azure
+                      DevOps webhook username and password (or PAT).'
+                    properties:
+                      passwordSecretRef:
+                        description: PasswordSecretRef points to the key holding the
+                          password or PAT.
+                        properties:
+                          key:
+                            description: Key in the Secret whose value should be used.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      usernameSecretRef:
+                        description: UsernameSecretRef points to the key holding the
+                          username.
+                        properties:
+                          key:
+                            description: Key in the Secret whose value should be used.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                    type: object
+                    x-kubernetes-validations:
+                    - message: usernameSecretRef and passwordSecretRef must be set
+                        together
+                      rule: (has(self.usernameSecretRef) && has(self.passwordSecretRef))
+                        || (!has(self.usernameSecretRef) && !has(self.passwordSecretRef))
+                  bitbucket:
+                    description: 'Bitbucket: Secret key reference for the Bitbucket
+                      Cloud webhook UUID.'
+                    properties:
+                      webhookUUIDSecretRef:
+                        description: WebhookUUIDSecretRef points to the key holding
+                          the Bitbucket Cloud webhook UUID.
+                        properties:
+                          key:
+                            description: Key in the Secret whose value should be used.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                    type: object
+                  bitbucketServer:
+                    description: 'BitbucketServer: Secret key reference for the Bitbucket
+                      Server webhook secret.'
+                    properties:
+                      webhookSecretRef:
+                        description: WebhookSecretRef points to the key holding the
+                          Bitbucket Server webhook shared secret.
+                        properties:
+                          key:
+                            description: Key in the Secret whose value should be used.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                    type: object
+                  github:
+                    description: 'GitHub: Secret key reference for the GitHub webhook
+                      shared secret.'
+                    properties:
+                      webhookSecretRef:
+                        description: WebhookSecretRef points to the key holding the
+                          GitHub webhook shared secret.
+                        properties:
+                          key:
+                            description: Key in the Secret whose value should be used.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                    type: object
+                  gitlab:
+                    description: 'GitLab: Secret key reference for the GitLab webhook
+                      shared secret.'
+                    properties:
+                      webhookSecretRef:
+                        description: WebhookSecretRef points to the key holding the
+                          GitLab webhook shared secret.
+                        properties:
+                          key:
+                            description: Key in the Secret whose value should be used.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                    type: object
+                  gogs:
+                    description: 'Gogs: Secret key reference for the Gogs webhook
+                      shared secret.'
+                    properties:
+                      webhookSecretRef:
+                        description: WebhookSecretRef points to the key holding the
+                          Gogs webhook shared secret.
+                        properties:
+                          key:
+                            description: Key in the Secret whose value should be used.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                    type: object
+                type: object
             type: object
           status:
             description: ArgoCDStatus defines the observed state of ArgoCD
@@ -9129,18 +9369,21 @@ spec:
                       type: string
                     description: Custom labels to pods deployed by the operator
                     type: object
-                  logLevel:
-                    description: LogLevel describes the log level that should be used
-                      by the ApplicationSet controller. Defaults to ArgoCDDefaultLogLevel
-                      if not set.  Valid options are debug,info, error, and warn.
-                    type: string
-                  logformat:
+                  logFormat:
                     description: LogFormat refers to the log format used by the ApplicationSet
                       component. Defaults to ArgoCDDefaultLogFormat if not configured.
                       Valid options are text or json.
                     enum:
                     - text
                     - json
+                    type: string
+                  logLevel:
+                    description: LogLevel describes the log level that should be used
+                      by the ApplicationSet controller. Defaults to ArgoCDDefaultLogLevel
+                      if not set.  Valid options are debug,info, error, and warn.
+                    type: string
+                  logformat:
+                    description: 'Deprecated: use LogFormat instead.'
                     type: string
                   resources:
                     description: Resources defines the Compute Resources required
@@ -11586,6 +11829,21 @@ spec:
                         description: LogLevel refers to the log level used by the
                           Agent component.
                         type: string
+                      metrics:
+                        description: Metrics defines the metrics configuration for
+                          the Agent ServiceMonitor.
+                        properties:
+                          interval:
+                            description: |-
+                              Interval specifies the Prometheus scrape interval for this component's ServiceMonitor.
+                              If empty, Prometheus uses its default scrape interval.
+                            type: string
+                          scrapeTimeout:
+                            description: |-
+                              ScrapeTimeout specifies the Prometheus scrape timeout for this component's ServiceMonitor.
+                              If empty, Prometheus uses the global scrape timeout.
+                            type: string
+                        type: object
                       redis:
                         description: Redis defines the Redis options for the Agent
                           component.
@@ -11594,6 +11852,66 @@ spec:
                             description: ServerAddress is the address of the Redis
                               server to be used by the PrincAgentipal component.
                             type: string
+                        type: object
+                      resources:
+                        description: Resources defines the Compute Resources required
+                          by the container for the Argo CD Agent agent component.
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This field depends on the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
                         type: object
                       tls:
                         description: TLS defines the TLS options for the Agent component.
@@ -11813,6 +12131,21 @@ spec:
                         description: LogLevel refers to the log level used by the
                           Principal component.
                         type: string
+                      metrics:
+                        description: Metrics defines the metrics configuration for
+                          the Principal ServiceMonitor.
+                        properties:
+                          interval:
+                            description: |-
+                              Interval specifies the Prometheus scrape interval for this component's ServiceMonitor.
+                              If empty, Prometheus uses its default scrape interval.
+                            type: string
+                          scrapeTimeout:
+                            description: |-
+                              ScrapeTimeout specifies the Prometheus scrape timeout for this component's ServiceMonitor.
+                              If empty, Prometheus uses the global scrape timeout.
+                            type: string
+                        type: object
                       namespace:
                         description: Namespace is the configuration for the Principal
                           component namespace.
@@ -11864,6 +12197,66 @@ spec:
                             description: SecretName is the name of the secret containing
                               the TLS certificate and key for the resource proxy.
                             type: string
+                        type: object
+                      resources:
+                        description: Resources defines the Compute Resources required
+                          by the container for the Argo CD Agent principal component.
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This field depends on the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
                         type: object
                       server:
                         description: Server defines the server options for the Principal
@@ -11945,11 +12338,20 @@ spec:
                 required:
                 - content
                 type: object
+              clusterDomain:
+                description: |-
+                  ClusterDomain is the cluster domain suffix used for constructing service FQDNs. Defaults to "cluster.local".
+                  The full FQDN will be: <service>.<namespace>.svc.<clusterDomain>
+                  This is useful for clusters that use a different DNS suffix (e.g., "CLUSTER_ID.cluster.local", "edge.local").
+                type: string
               cmdParams:
                 additionalProperties:
                   type: string
-                description: CmdParams specifies command-line parameters for the Argo
-                  CD components.
+                description: |-
+                  CmdParams specifies command-line parameters for the Argo CD components.
+                  The only keys currently supported for this parameter are:
+                  - controller.resource.health.persist
+                  - applicationsetcontroller.enable.tokenref.strict.mode — when ApplicationSet-in-any-namespace is active, the operator defaults this to "true"
                 type: object
               configManagementPlugins:
                 description: 'Deprecated: ConfigManagementPlugins field is no longer
@@ -13692,6 +14094,21 @@ spec:
                       Controller component. Defaults to ArgoCDDefaultLogLevel if not
                       configured. Valid options are debug, info, error, and warn.
                     type: string
+                  metrics:
+                    description: Metrics defines the metrics configuration for the
+                      Application Controller ServiceMonitor.
+                    properties:
+                      interval:
+                        description: |-
+                          Interval specifies the Prometheus scrape interval for this component's ServiceMonitor.
+                          If empty, Prometheus uses its default scrape interval.
+                        type: string
+                      scrapeTimeout:
+                        description: |-
+                          ScrapeTimeout specifies the Prometheus scrape timeout for this component's ServiceMonitor.
+                          If empty, Prometheus uses the global scrape timeout.
+                        type: string
+                    type: object
                   parallelismLimit:
                     description: ParallelismLimit defines the limit for parallel kubectl
                       operations
@@ -13780,6 +14197,15 @@ spec:
                     description: Sharding contains the options for the Application
                       Controller sharding configuration.
                     properties:
+                      algorithm:
+                        description: DistributionAlgorithm determines what algorithm
+                          will be used for distribution of shards. Valid options are
+                          legacy, round-robin, and consistent-hashing
+                        enum:
+                        - legacy
+                        - round-robin
+                        - consistent-hashing
+                        type: string
                       clustersPerShard:
                         description: ClustersPerShard defines the maximum number of
                           clusters managed by each argocd shard
@@ -18031,7 +18457,6 @@ spec:
                   NetworkPolicy resources for this Argo CD instance.
                 properties:
                   enabled:
-                    default: true
                     description: |-
                       Enabled defines whether NetworkPolicy resources are created for this Argo CD instance.
                       When enabled, the operator will reconcile NetworkPolicies for Argo CD components.
@@ -18259,12 +18684,7 @@ spec:
                   image:
                     description: Image is the Argo CD Notifications image (optional)
                     type: string
-                  logLevel:
-                    description: LogLevel describes the log level that should be used
-                      by the argocd-notifications. Defaults to ArgoCDDefaultLogLevel
-                      if not set.  Valid options are debug,info, error, and warn.
-                    type: string
-                  logformat:
+                  logFormat:
                     description: LogFormat refers to the log format used by the argocd-notifications.
                       Defaults to ArgoCDDefaultLogFormat if not configured. Valid
                       options are text or json.
@@ -18272,6 +18692,29 @@ spec:
                     - text
                     - json
                     type: string
+                  logLevel:
+                    description: LogLevel describes the log level that should be used
+                      by the argocd-notifications. Defaults to ArgoCDDefaultLogLevel
+                      if not set.  Valid options are debug,info, error, and warn.
+                    type: string
+                  logformat:
+                    description: 'Deprecated: use LogFormat instead.'
+                    type: string
+                  metrics:
+                    description: Metrics defines the metrics configuration for the
+                      Notifications ServiceMonitor.
+                    properties:
+                      interval:
+                        description: |-
+                          Interval specifies the Prometheus scrape interval for this component's ServiceMonitor.
+                          If empty, Prometheus uses its default scrape interval.
+                        type: string
+                      scrapeTimeout:
+                        description: |-
+                          ScrapeTimeout specifies the Prometheus scrape timeout for this component's ServiceMonitor.
+                          If empty, Prometheus uses the global scrape timeout.
+                        type: string
+                    type: object
                   replicas:
                     description: Replicas defines the number of replicas to run for
                       notifications-controller
@@ -20396,6 +20839,21 @@ spec:
                       by the Repo Server. Defaults to ArgoCDDefaultLogLevel if not
                       set.  Valid options are debug, info, error, and warn.
                     type: string
+                  metrics:
+                    description: Metrics defines the metrics configuration for the
+                      Repo Server ServiceMonitor.
+                    properties:
+                      interval:
+                        description: |-
+                          Interval specifies the Prometheus scrape interval for this component's ServiceMonitor.
+                          If empty, Prometheus uses its default scrape interval.
+                        type: string
+                      scrapeTimeout:
+                        description: |-
+                          ScrapeTimeout specifies the Prometheus scrape timeout for this component's ServiceMonitor.
+                          If empty, Prometheus uses the global scrape timeout.
+                        type: string
+                    type: object
                   mountsatoken:
                     description: MountSAToken describes whether you would like to
                       have the Repo server mount the service account token
@@ -26203,6 +26661,21 @@ spec:
                       ArgoCD Server component. Defaults to ArgoCDDefaultLogLevel if
                       not set.  Valid options are debug, info, error, and warn.
                     type: string
+                  metrics:
+                    description: Metrics defines the metrics configuration for the
+                      Server ServiceMonitor.
+                    properties:
+                      interval:
+                        description: |-
+                          Interval specifies the Prometheus scrape interval for this component's ServiceMonitor.
+                          If empty, Prometheus uses its default scrape interval.
+                        type: string
+                      scrapeTimeout:
+                        description: |-
+                          ScrapeTimeout specifies the Prometheus scrape timeout for this component's ServiceMonitor.
+                          If empty, Prometheus uses the global scrape timeout.
+                        type: string
+                    type: object
                   replicas:
                     description: Replicas defines the number of replicas for argocd-server.
                       Default is nil. Value should be greater than or equal to 0.
@@ -32216,6 +32689,149 @@ spec:
                 description: Version is the tag to use with the ArgoCD container image
                   for all ArgoCD components.
                 type: string
+              webTerminalEnabled:
+                description: WebTerminalEnabled allows you to get a shell inside a
+                  running pod just like you would with kubectl exec
+                type: boolean
+              webhookSecrets:
+                description: |-
+                  WebhookSecrets references Kubernetes Secrets that supply webhook credentials per provider.
+                  The operator syncs values into argocd-secret under the keys Argo CD expects.
+                properties:
+                  azureDevOps:
+                    description: 'AzureDevOps: Secret key references for the Azure
+                      DevOps webhook username and password (or PAT).'
+                    properties:
+                      passwordSecretRef:
+                        description: PasswordSecretRef points to the key holding the
+                          password or PAT.
+                        properties:
+                          key:
+                            description: Key in the Secret whose value should be used.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      usernameSecretRef:
+                        description: UsernameSecretRef points to the key holding the
+                          username.
+                        properties:
+                          key:
+                            description: Key in the Secret whose value should be used.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                    type: object
+                    x-kubernetes-validations:
+                    - message: usernameSecretRef and passwordSecretRef must be set
+                        together
+                      rule: (has(self.usernameSecretRef) && has(self.passwordSecretRef))
+                        || (!has(self.usernameSecretRef) && !has(self.passwordSecretRef))
+                  bitbucket:
+                    description: 'Bitbucket: Secret key reference for the Bitbucket
+                      Cloud webhook UUID.'
+                    properties:
+                      webhookUUIDSecretRef:
+                        description: WebhookUUIDSecretRef points to the key holding
+                          the Bitbucket Cloud webhook UUID.
+                        properties:
+                          key:
+                            description: Key in the Secret whose value should be used.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                    type: object
+                  bitbucketServer:
+                    description: 'BitbucketServer: Secret key reference for the Bitbucket
+                      Server webhook secret.'
+                    properties:
+                      webhookSecretRef:
+                        description: WebhookSecretRef points to the key holding the
+                          Bitbucket Server webhook shared secret.
+                        properties:
+                          key:
+                            description: Key in the Secret whose value should be used.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                    type: object
+                  github:
+                    description: 'GitHub: Secret key reference for the GitHub webhook
+                      shared secret.'
+                    properties:
+                      webhookSecretRef:
+                        description: WebhookSecretRef points to the key holding the
+                          GitHub webhook shared secret.
+                        properties:
+                          key:
+                            description: Key in the Secret whose value should be used.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                    type: object
+                  gitlab:
+                    description: 'GitLab: Secret key reference for the GitLab webhook
+                      shared secret.'
+                    properties:
+                      webhookSecretRef:
+                        description: WebhookSecretRef points to the key holding the
+                          GitLab webhook shared secret.
+                        properties:
+                          key:
+                            description: Key in the Secret whose value should be used.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                    type: object
+                  gogs:
+                    description: 'Gogs: Secret key reference for the Gogs webhook
+                      shared secret.'
+                    properties:
+                      webhookSecretRef:
+                        description: WebhookSecretRef points to the key holding the
+                          Gogs webhook shared secret.
+                        properties:
+                          key:
+                            description: Key in the Secret whose value should be used.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                    type: object
+                type: object
             type: object
             x-kubernetes-validations:
             - message: spec.sso and spec.oidcConfig cannot both be set

--- a/containers/gitops-operator-bundle/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/containers/gitops-operator-bundle/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -189,8 +189,8 @@ metadata:
       ]
     capabilities: Deep Insights
     console.openshift.io/plugins: '["gitops-plugin"]'
-    containerImage: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:9a750e7d84ce0ec4b671b0fc0ea27b7cb8850d0f7a98ba3105f3fc8416536d24
-    createdAt: "2026-06-03T18:12:37Z"
+    containerImage: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:6ac479acf6534855cdebc53f1583f19c677e09823f15f42e4c5dc08040f9e6da
+    createdAt: "2026-06-12T08:52:50Z"
     description: Enables teams to adopt GitOps principles for managing cluster configurations and application delivery across hybrid multi-cluster Kubernetes environments.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -208,7 +208,7 @@ metadata:
     support: Red Hat
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/internal-objects: '["gitopsservices.pipelines.openshift.io"]'
-    operators.openshift.io/must-gather-image: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:5fb430190af229976f52b4491a52bd723a7596a17322e140b0ee368ed0c9ae36
+    operators.openshift.io/must-gather-image: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:47713bffed7c84196c871de73a2fc9bcba6ae238e11f80de4dcd4fb41656aa86
     features.operators.openshift.io/cnf: 'false'
     features.operators.openshift.io/cni: 'false'
     features.operators.openshift.io/csi: 'false'
@@ -855,19 +855,19 @@ spec:
                       - name: ENABLE_CONVERSION_WEBHOOK
                         value: 'true'
                       - name: RELATED_IMAGE_ARGOCD_DEX_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:ec5bbc27642ebcf70cba4f72de8037fd41869ebb9a73c9f4de37c8eb0a67de08
+                        value: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:e67293391eb1b2fb23d09e0ff233fecc9d0cadff9d354ee8022c7c416f148e57
                       - name: ARGOCD_DEX_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:ec5bbc27642ebcf70cba4f72de8037fd41869ebb9a73c9f4de37c8eb0a67de08
+                        value: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:e67293391eb1b2fb23d09e0ff233fecc9d0cadff9d354ee8022c7c416f148e57
                       - name: RELATED_IMAGE_BACKEND_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:b1408a87ab0908685f649ff0cd80a4a406b41f88f32fa0ea7a0a903dca475ffc
+                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:07f93745d6526b4357afe0d588e11f8a4a37a243a9ce93f59a84839e3f5ad146
                       - name: BACKEND_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:b1408a87ab0908685f649ff0cd80a4a406b41f88f32fa0ea7a0a903dca475ffc
+                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:07f93745d6526b4357afe0d588e11f8a4a37a243a9ce93f59a84839e3f5ad146
                       - name: RELATED_IMAGE_ARGOCD_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:23203e8df1ecf90ab8bb35400a48bd778b5d20bf75a16b5e3af1d7ffb1a4d251
+                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:1ae0ea1838b24aab46d3862a78c0d3cec14ab2db67a677a4e4cba6393531ed6a
                       - name: ARGOCD_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:23203e8df1ecf90ab8bb35400a48bd778b5d20bf75a16b5e3af1d7ffb1a4d251
+                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:1ae0ea1838b24aab46d3862a78c0d3cec14ab2db67a677a4e4cba6393531ed6a
                       - name: ARGOCD_REPOSERVER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:23203e8df1ecf90ab8bb35400a48bd778b5d20bf75a16b5e3af1d7ffb1a4d251
+                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:1ae0ea1838b24aab46d3862a78c0d3cec14ab2db67a677a4e4cba6393531ed6a
                       - name: RELATED_IMAGE_ARGOCD_REDIS_IMAGE
                         value: registry.redhat.io/rhel9/redis-7@sha256:3d31c0cfaf4219f5bd1c52882b603215d1cb4aaef5b8d1a128d0174e090f96f3
                       - name: ARGOCD_REDIS_IMAGE
@@ -879,32 +879,32 @@ spec:
                       - name: ARGOCD_REDIS_HA_PROXY_IMAGE
                         value: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:94b623471456a7ce697eff5afbcc74cf106077e1fe81b982a840fa132fcdbad0
                       - name: RELATED_IMAGE_GITOPS_CONSOLE_PLUGIN_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:f8b345bf2c38dfd15d691766d9079e05478d05cc04582dd7838eb92178e69b90
+                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:34c89ad0fc6a8488db1a00dc1c01a78296d168daf73b819b9f92f4fa3960e281
                       - name: GITOPS_CONSOLE_PLUGIN_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:f8b345bf2c38dfd15d691766d9079e05478d05cc04582dd7838eb92178e69b90
+                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:34c89ad0fc6a8488db1a00dc1c01a78296d168daf73b819b9f92f4fa3960e281
                       - name: RELATED_IMAGE_ARGOCD_EXTENSION_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:4fa80131305a4fda75cde23700597cfdc5e637a7a8f36b16a766f4db4f3463ed
+                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:5d2700260dec25d08c165baab65c918798636a33a129302fd4a66de4a6a988e8
                       - name: ARGOCD_EXTENSION_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:4fa80131305a4fda75cde23700597cfdc5e637a7a8f36b16a766f4db4f3463ed
+                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:5d2700260dec25d08c165baab65c918798636a33a129302fd4a66de4a6a988e8
                       - name: RELATED_IMAGE_ARGO_ROLLOUTS_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:3e3873a48a41aa7c98c1a197903659f3cd0ddf1c89bffbd2cdbff45d345305c7
+                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:9e4bd498545854da2697d947252964dcd752a58dbc0ef78e56cbd5c3a20fd6ad
                       - name: ARGO_ROLLOUTS_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:3e3873a48a41aa7c98c1a197903659f3cd0ddf1c89bffbd2cdbff45d345305c7
+                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:9e4bd498545854da2697d947252964dcd752a58dbc0ef78e56cbd5c3a20fd6ad
                       - name: RELATED_IMAGE_MUST_GATHER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:5fb430190af229976f52b4491a52bd723a7596a17322e140b0ee368ed0c9ae36
+                        value: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:47713bffed7c84196c871de73a2fc9bcba6ae238e11f80de4dcd4fb41656aa86
                       - name: ARGOCD_PRINCIPAL_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:bd247b4237fb5bf09a4acc59cee3bb6f92f565ba4e0e67a70b20b0b8ed871a8d
+                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:e9fdd3fd8545ab7330e57e49f29b8c864eb65d05ead75c83a35f84cda2cef60b
                       - name: RELATED_IMAGE_ARGOCD_PRINCIPAL_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:bd247b4237fb5bf09a4acc59cee3bb6f92f565ba4e0e67a70b20b0b8ed871a8d
+                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:e9fdd3fd8545ab7330e57e49f29b8c864eb65d05ead75c83a35f84cda2cef60b
                       - name: ARGOCD_AGENT_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:bd247b4237fb5bf09a4acc59cee3bb6f92f565ba4e0e67a70b20b0b8ed871a8d
+                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:e9fdd3fd8545ab7330e57e49f29b8c864eb65d05ead75c83a35f84cda2cef60b
                       - name: RELATED_IMAGE_ARGOCD_AGENT_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:bd247b4237fb5bf09a4acc59cee3bb6f92f565ba4e0e67a70b20b0b8ed871a8d
+                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:e9fdd3fd8545ab7330e57e49f29b8c864eb65d05ead75c83a35f84cda2cef60b
                       - name: ARGOCD_IMAGE_UPDATER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:98f62234a12c5c7124c21c9bc8874b0cbfaa943e7a848fff5d97db98bd8211e3
+                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:13c6b87e6e8b05adbe1a266ade52b69a17b105d862de39b1dedc13ec144d0a8c
                       - name: RELATED_IMAGE_ARGOCD_IMAGE_UPDATER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:98f62234a12c5c7124c21c9bc8874b0cbfaa943e7a848fff5d97db98bd8211e3
-                    image: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:9a750e7d84ce0ec4b671b0fc0ea27b7cb8850d0f7a98ba3105f3fc8416536d24
+                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:13c6b87e6e8b05adbe1a266ade52b69a17b105d862de39b1dedc13ec144d0a8c
+                    image: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:6ac479acf6534855cdebc53f1583f19c677e09823f15f42e4c5dc08040f9e6da
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -1011,28 +1011,28 @@ spec:
       webhookPath: /convert
   relatedImages:
     - name: manager
-      image: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:9a750e7d84ce0ec4b671b0fc0ea27b7cb8850d0f7a98ba3105f3fc8416536d24
+      image: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:6ac479acf6534855cdebc53f1583f19c677e09823f15f42e4c5dc08040f9e6da
     - name: argocd_dex_image
-      image: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:ec5bbc27642ebcf70cba4f72de8037fd41869ebb9a73c9f4de37c8eb0a67de08
+      image: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:e67293391eb1b2fb23d09e0ff233fecc9d0cadff9d354ee8022c7c416f148e57
     - name: backend_image
-      image: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:b1408a87ab0908685f649ff0cd80a4a406b41f88f32fa0ea7a0a903dca475ffc
+      image: registry.redhat.io/openshift-gitops-1/gitops-rhel9@sha256:07f93745d6526b4357afe0d588e11f8a4a37a243a9ce93f59a84839e3f5ad146
     - name: argocd_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:23203e8df1ecf90ab8bb35400a48bd778b5d20bf75a16b5e3af1d7ffb1a4d251
+      image: registry.redhat.io/openshift-gitops-1/argocd-rhel9@sha256:1ae0ea1838b24aab46d3862a78c0d3cec14ab2db67a677a4e4cba6393531ed6a
     - name: argocd_redis_image
       image: registry.redhat.io/rhel9/redis-7@sha256:3d31c0cfaf4219f5bd1c52882b603215d1cb4aaef5b8d1a128d0174e090f96f3
     - name: argocd_redis_ha_proxy_image
       image: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:94b623471456a7ce697eff5afbcc74cf106077e1fe81b982a840fa132fcdbad0
     - name: gitops_console_plugin_image
-      image: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:f8b345bf2c38dfd15d691766d9079e05478d05cc04582dd7838eb92178e69b90
+      image: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:34c89ad0fc6a8488db1a00dc1c01a78296d168daf73b819b9f92f4fa3960e281
     - name: argocd_extension_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:4fa80131305a4fda75cde23700597cfdc5e637a7a8f36b16a766f4db4f3463ed
+      image: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel9@sha256:5d2700260dec25d08c165baab65c918798636a33a129302fd4a66de4a6a988e8
     - name: argo_rollouts_image
-      image: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:3e3873a48a41aa7c98c1a197903659f3cd0ddf1c89bffbd2cdbff45d345305c7
+      image: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel9@sha256:9e4bd498545854da2697d947252964dcd752a58dbc0ef78e56cbd5c3a20fd6ad
     - name: must_gather_image
-      image: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:5fb430190af229976f52b4491a52bd723a7596a17322e140b0ee368ed0c9ae36
+      image: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:47713bffed7c84196c871de73a2fc9bcba6ae238e11f80de4dcd4fb41656aa86
     - name: argocd_principal_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:bd247b4237fb5bf09a4acc59cee3bb6f92f565ba4e0e67a70b20b0b8ed871a8d
+      image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:e9fdd3fd8545ab7330e57e49f29b8c864eb65d05ead75c83a35f84cda2cef60b
     - name: argocd_agent_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:bd247b4237fb5bf09a4acc59cee3bb6f92f565ba4e0e67a70b20b0b8ed871a8d
+      image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:e9fdd3fd8545ab7330e57e49f29b8c864eb65d05ead75c83a35f84cda2cef60b
     - name: argocd_image_updater_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:98f62234a12c5c7124c21c9bc8874b0cbfaa943e7a848fff5d97db98bd8211e3
+      image: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:13c6b87e6e8b05adbe1a266ade52b69a17b105d862de39b1dedc13ec144d0a8c


### PR DESCRIPTION
This PR updates the bundle files with the latest image shas for release-1.21 tag.

Automatically generated from `release-1.21` branch using GitHub Actions.