### PR TITLE
chore(bundle): latest bundle updates for v1.19.5-1

### DIFF
--- a/containers/gitops-operator-bundle/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/containers/gitops-operator-bundle/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -179,7 +179,7 @@ metadata:
       ]
     capabilities: Deep Insights
     console.openshift.io/plugins: '["gitops-plugin"]'
-    containerImage: registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator@sha256:9a218d28c0a395d21ce840c9e17000da42781a4f5fbe9cdb3045a6364a44d3fc
+    containerImage: registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator@sha256:a9198829e9d08d5eb19e7719b50b30a77152a1632046f37bdc126d269f7d511a
     createdAt: "2026-02-23T08:01:55Z"
     description: Enables teams to adopt GitOps principles for managing cluster configurations and application delivery across hybrid multi-cluster Kubernetes environments.
     features.operators.openshift.io/disconnected: "true"
@@ -198,12 +198,12 @@ metadata:
     support: Red Hat
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/internal-objects: '["gitopsservices.pipelines.openshift.io"]'
-    operators.openshift.io/must-gather-image: registry.redhat.io/openshift-gitops-1/must-gather-rhel8@sha256:b49aa8adfd5c0b6fe139fb830addcbe00edbf6e245b351778ffd113f6da2f894
+    operators.openshift.io/must-gather-image: registry.redhat.io/openshift-gitops-1/must-gather-rhel8@sha256:e20a7315654a77d566a90071b9921f5c5c3dff0b16398de66c2806bb99bd2618
     features.operators.openshift.io/cnf: 'false'
     features.operators.openshift.io/cni: 'false'
     features.operators.openshift.io/csi: 'false'
     olm.skipRange: ""
-  name: openshift-gitops-operator.v1.19.4
+  name: openshift-gitops-operator.v1.19.5
   namespace: placeholder
   labels:
     operatorframework.io/os.linux: supported
@@ -840,19 +840,19 @@ spec:
                       - name: ENABLE_CONVERSION_WEBHOOK
                         value: 'true'
                       - name: RELATED_IMAGE_ARGOCD_DEX_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/dex-rhel8@sha256:27643390cbf693b5dc3dd864c0b121532b69fd80ccfe972c2dde961555b2f9eb
+                        value: registry.redhat.io/openshift-gitops-1/dex-rhel8@sha256:8e067c429603f25c17a186bd04fe4e12653751ed682c21bc161c78ae2626c54c
                       - name: ARGOCD_DEX_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/dex-rhel8@sha256:27643390cbf693b5dc3dd864c0b121532b69fd80ccfe972c2dde961555b2f9eb
+                        value: registry.redhat.io/openshift-gitops-1/dex-rhel8@sha256:8e067c429603f25c17a186bd04fe4e12653751ed682c21bc161c78ae2626c54c
                       - name: RELATED_IMAGE_BACKEND_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel8@sha256:2c300a522bd63a7f5eb2d15f60a9b261a63077eb5df782785d83a30a42568cf3
+                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel8@sha256:c82fb37e05d8b59481c1af3a5bdd341c670a910c0fdd829c39995abf472bf30a
                       - name: BACKEND_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel8@sha256:2c300a522bd63a7f5eb2d15f60a9b261a63077eb5df782785d83a30a42568cf3
+                        value: registry.redhat.io/openshift-gitops-1/gitops-rhel8@sha256:c82fb37e05d8b59481c1af3a5bdd341c670a910c0fdd829c39995abf472bf30a
                       - name: RELATED_IMAGE_ARGOCD_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel8@sha256:20dd97427f9f4a701c4335e5bae59e2787a9ec1a13f909ba4f5e99f0299dcc3c
+                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel8@sha256:09e6f64d59661467f67f44e3c021a1fc3ee07864442e862bf0910010a9df3c2e
                       - name: ARGOCD_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel8@sha256:20dd97427f9f4a701c4335e5bae59e2787a9ec1a13f909ba4f5e99f0299dcc3c
+                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel8@sha256:09e6f64d59661467f67f44e3c021a1fc3ee07864442e862bf0910010a9df3c2e
                       - name: ARGOCD_REPOSERVER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel8@sha256:20dd97427f9f4a701c4335e5bae59e2787a9ec1a13f909ba4f5e99f0299dcc3c
+                        value: registry.redhat.io/openshift-gitops-1/argocd-rhel8@sha256:09e6f64d59661467f67f44e3c021a1fc3ee07864442e862bf0910010a9df3c2e
                       - name: RELATED_IMAGE_ARGOCD_REDIS_IMAGE
                         value: registry.redhat.io/rhel9/redis-7@sha256:3d31c0cfaf4219f5bd1c52882b603215d1cb4aaef5b8d1a128d0174e090f96f3
                       - name: ARGOCD_REDIS_IMAGE
@@ -860,34 +860,34 @@ spec:
                       - name: ARGOCD_REDIS_HA_IMAGE
                         value: registry.redhat.io/rhel9/redis-7@sha256:3d31c0cfaf4219f5bd1c52882b603215d1cb4aaef5b8d1a128d0174e090f96f3
                       - name: RELATED_IMAGE_ARGOCD_REDIS_HA_PROXY_IMAGE
-                        value: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:e65c2e85e9aeba1984744498c0fe6e495a63f0cd5a641b57cca427095b5721fc
+                        value: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:f446cc5e14043c426638ddd1afdd9d5ace5d1512bb924a594a76f210f39f21b7
                       - name: ARGOCD_REDIS_HA_PROXY_IMAGE
-                        value: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:e65c2e85e9aeba1984744498c0fe6e495a63f0cd5a641b57cca427095b5721fc
+                        value: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:f446cc5e14043c426638ddd1afdd9d5ace5d1512bb924a594a76f210f39f21b7
                       - name: RELATED_IMAGE_GITOPS_CONSOLE_PLUGIN_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel8@sha256:36d702f13c864305ab1ceffb80ae0a13ad3101552460c2295cb1aac2a1bff594
+                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel8@sha256:5c7dfda4b30f219cbef37eca7402c4a92599b8f4c56dedee1889c1bf39056cda
                       - name: GITOPS_CONSOLE_PLUGIN_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel8@sha256:36d702f13c864305ab1ceffb80ae0a13ad3101552460c2295cb1aac2a1bff594
+                        value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel8@sha256:5c7dfda4b30f219cbef37eca7402c4a92599b8f4c56dedee1889c1bf39056cda
                       - name: RELATED_IMAGE_ARGOCD_EXTENSION_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel8@sha256:8a7f6ac3131118e6c7fc87fcd52ade0de0a337210d95449b98852f7db5976fa6
+                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel8@sha256:1685d74942d536d8526d92533f675486a81be43bfd0c7d30d4ea86a4b7abd8f1
                       - name: ARGOCD_EXTENSION_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel8@sha256:8a7f6ac3131118e6c7fc87fcd52ade0de0a337210d95449b98852f7db5976fa6
+                        value: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel8@sha256:1685d74942d536d8526d92533f675486a81be43bfd0c7d30d4ea86a4b7abd8f1
                       - name: RELATED_IMAGE_ARGO_ROLLOUTS_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel8@sha256:371b51b6a7659acc5861d1e061ed80d2dffcbbdceb30f8829a9bea57291e013a
+                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel8@sha256:03f5c0dcbf3c77993ebd0678d0dc33d4c087c614f362da4f6df707843f6e4c8a
                       - name: ARGO_ROLLOUTS_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel8@sha256:371b51b6a7659acc5861d1e061ed80d2dffcbbdceb30f8829a9bea57291e013a
+                        value: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel8@sha256:03f5c0dcbf3c77993ebd0678d0dc33d4c087c614f362da4f6df707843f6e4c8a
                       - name: RELATED_IMAGE_MUST_GATHER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/must-gather-rhel8@sha256:b49aa8adfd5c0b6fe139fb830addcbe00edbf6e245b351778ffd113f6da2f894
+                        value: registry.redhat.io/openshift-gitops-1/must-gather-rhel8@sha256:e20a7315654a77d566a90071b9921f5c5c3dff0b16398de66c2806bb99bd2618
                       - name: RELATED_IMAGE_KUBE_RBAC_PROXY_IMAGE
-                        value: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:73ef841545cc3eea70c00ec70ce6ee5e092ff77631d551d22e8524b2bb9f96b7
+                        value: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:f2bd969d956e82fbfaedfb4f745579899b051e92b287cafd7a28433ecc9ff931
                       - name: ARGOCD_PRINCIPAL_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel8@sha256:843beee7e124397d677966656349336335282fda7b53a4d069c3d4af00dd2422
+                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel8@sha256:748eedd8724c04c67ba4adc84178c283aa789f7a833e53995e35d76b0974f989
                       - name: RELATED_IMAGE_ARGOCD_PRINCIPAL_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel8@sha256:843beee7e124397d677966656349336335282fda7b53a4d069c3d4af00dd2422
+                        value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel8@sha256:748eedd8724c04c67ba4adc84178c283aa789f7a833e53995e35d76b0974f989
                       - name: ARGOCD_IMAGE_UPDATER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel8@sha256:72cfeafdaeaec20f46fe38df46b4b2d0f1e2ec66341d9f5328a23d049cec644f
+                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel8@sha256:99636ccff9735044285148f7bd4ff4bca18f176d566d81989db6dd07ed87e419
                       - name: RELATED_IMAGE_ARGOCD_IMAGE_UPDATER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel8@sha256:72cfeafdaeaec20f46fe38df46b4b2d0f1e2ec66341d9f5328a23d049cec644f
-                    image: registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator@sha256:9a218d28c0a395d21ce840c9e17000da42781a4f5fbe9cdb3045a6364a44d3fc
+                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel8@sha256:99636ccff9735044285148f7bd4ff4bca18f176d566d81989db6dd07ed87e419
+                    image: registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator@sha256:a9198829e9d08d5eb19e7719b50b30a77152a1632046f37bdc126d269f7d511a
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -921,7 +921,7 @@ spec:
                       - --logtostderr=true
                       - --allow-paths=/metrics
                       - --http2-disable
-                    image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:73ef841545cc3eea70c00ec70ce6ee5e092ff77631d551d22e8524b2bb9f96b7
+                    image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:f2bd969d956e82fbfaedfb4f745579899b051e92b287cafd7a28433ecc9ff931
                     name: kube-rbac-proxy
                     ports:
                       - containerPort: 8443
@@ -1005,8 +1005,8 @@ spec:
   maturity: GA
   provider:
     name: Red Hat Inc
-  replaces: "openshift-gitops-operator.v1.19.3"
-  version: 1.19.4
+  replaces: "openshift-gitops-operator.v1.19.4"
+  version: 1.19.5
   webhookdefinitions:
     - admissionReviewVersions:
         - v1alpha1
@@ -1022,30 +1022,30 @@ spec:
       webhookPath: /convert
   relatedImages:
     - name: manager
-      image: registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator@sha256:9a218d28c0a395d21ce840c9e17000da42781a4f5fbe9cdb3045a6364a44d3fc
+      image: registry.redhat.io/openshift-gitops-1/gitops-rhel8-operator@sha256:a9198829e9d08d5eb19e7719b50b30a77152a1632046f37bdc126d269f7d511a
     - name: kube-rbac-proxy
-      image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:73ef841545cc3eea70c00ec70ce6ee5e092ff77631d551d22e8524b2bb9f96b7
+      image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:f2bd969d956e82fbfaedfb4f745579899b051e92b287cafd7a28433ecc9ff931
     - name: kube_rbac_proxy_image
-      image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:73ef841545cc3eea70c00ec70ce6ee5e092ff77631d551d22e8524b2bb9f96b7
+      image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:f2bd969d956e82fbfaedfb4f745579899b051e92b287cafd7a28433ecc9ff931
     - name: argocd_dex_image
-      image: registry.redhat.io/openshift-gitops-1/dex-rhel8@sha256:27643390cbf693b5dc3dd864c0b121532b69fd80ccfe972c2dde961555b2f9eb
+      image: registry.redhat.io/openshift-gitops-1/dex-rhel8@sha256:8e067c429603f25c17a186bd04fe4e12653751ed682c21bc161c78ae2626c54c
     - name: backend_image
-      image: registry.redhat.io/openshift-gitops-1/gitops-rhel8@sha256:2c300a522bd63a7f5eb2d15f60a9b261a63077eb5df782785d83a30a42568cf3
+      image: registry.redhat.io/openshift-gitops-1/gitops-rhel8@sha256:c82fb37e05d8b59481c1af3a5bdd341c670a910c0fdd829c39995abf472bf30a
     - name: argocd_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-rhel8@sha256:20dd97427f9f4a701c4335e5bae59e2787a9ec1a13f909ba4f5e99f0299dcc3c
+      image: registry.redhat.io/openshift-gitops-1/argocd-rhel8@sha256:09e6f64d59661467f67f44e3c021a1fc3ee07864442e862bf0910010a9df3c2e
     - name: argocd_redis_image
       image: registry.redhat.io/rhel9/redis-7@sha256:3d31c0cfaf4219f5bd1c52882b603215d1cb4aaef5b8d1a128d0174e090f96f3
     - name: argocd_redis_ha_proxy_image
-      image: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:e65c2e85e9aeba1984744498c0fe6e495a63f0cd5a641b57cca427095b5721fc
+      image: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:f446cc5e14043c426638ddd1afdd9d5ace5d1512bb924a594a76f210f39f21b7
     - name: gitops_console_plugin_image
-      image: registry.redhat.io/openshift-gitops-1/console-plugin-rhel8@sha256:36d702f13c864305ab1ceffb80ae0a13ad3101552460c2295cb1aac2a1bff594
+      image: registry.redhat.io/openshift-gitops-1/console-plugin-rhel8@sha256:5c7dfda4b30f219cbef37eca7402c4a92599b8f4c56dedee1889c1bf39056cda
     - name: argocd_extension_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel8@sha256:8a7f6ac3131118e6c7fc87fcd52ade0de0a337210d95449b98852f7db5976fa6
+      image: registry.redhat.io/openshift-gitops-1/argocd-extensions-rhel8@sha256:1685d74942d536d8526d92533f675486a81be43bfd0c7d30d4ea86a4b7abd8f1
     - name: argo_rollouts_image
-      image: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel8@sha256:371b51b6a7659acc5861d1e061ed80d2dffcbbdceb30f8829a9bea57291e013a
+      image: registry.redhat.io/openshift-gitops-1/argo-rollouts-rhel8@sha256:03f5c0dcbf3c77993ebd0678d0dc33d4c087c614f362da4f6df707843f6e4c8a
     - name: must_gather_image
-      image: registry.redhat.io/openshift-gitops-1/must-gather-rhel8@sha256:b49aa8adfd5c0b6fe139fb830addcbe00edbf6e245b351778ffd113f6da2f894
+      image: registry.redhat.io/openshift-gitops-1/must-gather-rhel8@sha256:e20a7315654a77d566a90071b9921f5c5c3dff0b16398de66c2806bb99bd2618
     - name: argocd_principal_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel8@sha256:843beee7e124397d677966656349336335282fda7b53a4d069c3d4af00dd2422
+      image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel8@sha256:748eedd8724c04c67ba4adc84178c283aa789f7a833e53995e35d76b0974f989
     - name: argocd_image_updater_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel8@sha256:72cfeafdaeaec20f46fe38df46b4b2d0f1e2ec66341d9f5328a23d049cec644f
+      image: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel8@sha256:99636ccff9735044285148f7bd4ff4bca18f176d566d81989db6dd07ed87e419


### PR DESCRIPTION
This PR updates the bundle files with the latest image shas for release-1.19 tag.

Automatically generated from `release-1.19` branch using GitHub Actions.