### PR TITLE
feat(argocd): Add symlink for Argo CD commit server to `argocd` image

### DIFF
--- a/containers/argocd/Dockerfile
+++ b/containers/argocd/Dockerfile
@@ -171,6 +171,7 @@ WORKDIR /home/argocd
 COPY --from=argocd-build /go/src/github.com/argoproj/argo-cd/dist/argocd /usr/local/bin/
 RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-cmp-server
 RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-server
+RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-commit-server
 RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-repo-server
 RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-application-controller
 RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-dex


### PR DESCRIPTION
Preparing for commit-server downstreaming.

Ref.: https://redhat.atlassian.net/browse/GITOPS-9347