### PR TITLE
chore(bundle): latest bundle updates for v1.20.6-2

### DIFF
--- a/containers/gitops-operator-bundle/bundle/manifests/gitops-operator.clusterserviceversion.yaml
+++ b/containers/gitops-operator-bundle/bundle/manifests/gitops-operator.clusterserviceversion.yaml
@@ -863,9 +863,9 @@ spec:
                       - name: ARGOCD_REDIS_HA_IMAGE
                         value: registry.redhat.io/rhel9/redis-7@sha256:3d31c0cfaf4219f5bd1c52882b603215d1cb4aaef5b8d1a128d0174e090f96f3
                       - name: RELATED_IMAGE_ARGOCD_REDIS_HA_PROXY_IMAGE
-                        value: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:89ea883a696936a16a0e541ac5f1c12188a003ef55df32d725949d473162bcc2
+                        value: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:e86d3fa003541bc52fe162946cb5e9ba2d179e0f0ea7fb9c6b7b875e73b4aeec
                       - name: ARGOCD_REDIS_HA_PROXY_IMAGE
-                        value: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:89ea883a696936a16a0e541ac5f1c12188a003ef55df32d725949d473162bcc2
+                        value: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:e86d3fa003541bc52fe162946cb5e9ba2d179e0f0ea7fb9c6b7b875e73b4aeec
                       - name: RELATED_IMAGE_GITOPS_CONSOLE_PLUGIN_IMAGE
                         value: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:439f47ffa36e91072316d142d05f4778b89247b0b9ac6689a1850f8552fde236
                       - name: GITOPS_CONSOLE_PLUGIN_IMAGE
@@ -881,7 +881,7 @@ spec:
                       - name: RELATED_IMAGE_MUST_GATHER_IMAGE
                         value: registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:80c3b53b2633a912c788b1d39b9a68967d278b08041b04aaffad5c53f35b7e09
                       - name: RELATED_IMAGE_KUBE_RBAC_PROXY_IMAGE
-                        value: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:7f4ae1cd56e5b62d03125e4d26013717fc641f1b0d257a6f66ae343274053479
+                        value: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:f027852c5fe3b34563e2e78e28a265621775379343537675d4b6853e1321eef8
                       - name: ARGOCD_PRINCIPAL_IMAGE
                         value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:9c4775d30c4e7c250570b3f60accbe41368dee4ed04279a3a1b07681d1d95fdd
                       - name: RELATED_IMAGE_ARGOCD_PRINCIPAL_IMAGE
@@ -891,9 +891,9 @@ spec:
                       - name: RELATED_IMAGE_ARGOCD_AGENT_IMAGE
                         value: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:9c4775d30c4e7c250570b3f60accbe41368dee4ed04279a3a1b07681d1d95fdd
                       - name: ARGOCD_IMAGE_UPDATER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:4393a4a47b2e902ade4ac37161c590c835736df68542b15c75034e75915c2ec0
+                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:b3f368b45f533b72798c60bc7404a6b1bf1a402f3a484bdf0f6be802e925e611
                       - name: RELATED_IMAGE_ARGOCD_IMAGE_UPDATER_IMAGE
-                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:4393a4a47b2e902ade4ac37161c590c835736df68542b15c75034e75915c2ec0
+                        value: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:b3f368b45f533b72798c60bc7404a6b1bf1a402f3a484bdf0f6be802e925e611
                     image: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:5262790aa7f209b0321f83dfabef35572b2689b2efa8ab9b2088d6c596dcc61b
                     livenessProbe:
                       httpGet:
@@ -928,7 +928,7 @@ spec:
                       - --logtostderr=true
                       - --allow-paths=/metrics
                       - --http2-disable
-                    image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:7f4ae1cd56e5b62d03125e4d26013717fc641f1b0d257a6f66ae343274053479
+                    image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:f027852c5fe3b34563e2e78e28a265621775379343537675d4b6853e1321eef8
                     name: kube-rbac-proxy
                     ports:
                       - containerPort: 8443
@@ -1031,9 +1031,9 @@ spec:
     - name: manager
       image: registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:5262790aa7f209b0321f83dfabef35572b2689b2efa8ab9b2088d6c596dcc61b
     - name: kube-rbac-proxy
-      image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:7f4ae1cd56e5b62d03125e4d26013717fc641f1b0d257a6f66ae343274053479
+      image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:f027852c5fe3b34563e2e78e28a265621775379343537675d4b6853e1321eef8
     - name: kube_rbac_proxy_image
-      image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:7f4ae1cd56e5b62d03125e4d26013717fc641f1b0d257a6f66ae343274053479
+      image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:f027852c5fe3b34563e2e78e28a265621775379343537675d4b6853e1321eef8
     - name: argocd_dex_image
       image: registry.redhat.io/openshift-gitops-1/dex-rhel9@sha256:e0afbb4e4fe956b7406e4cdcbc311e9b25c2c68df2c3dcd4b1082045e329dc8a
     - name: backend_image
@@ -1043,7 +1043,7 @@ spec:
     - name: argocd_redis_image
       image: registry.redhat.io/rhel9/redis-7@sha256:3d31c0cfaf4219f5bd1c52882b603215d1cb4aaef5b8d1a128d0174e090f96f3
     - name: argocd_redis_ha_proxy_image
-      image: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:89ea883a696936a16a0e541ac5f1c12188a003ef55df32d725949d473162bcc2
+      image: registry.redhat.io/openshift4/ose-haproxy-router-rhel9@sha256:e86d3fa003541bc52fe162946cb5e9ba2d179e0f0ea7fb9c6b7b875e73b4aeec
     - name: gitops_console_plugin_image
       image: registry.redhat.io/openshift-gitops-1/console-plugin-rhel9@sha256:439f47ffa36e91072316d142d05f4778b89247b0b9ac6689a1850f8552fde236
     - name: argocd_extension_image
@@ -1057,4 +1057,4 @@ spec:
     - name: argocd_agent_image
       image: registry.redhat.io/openshift-gitops-1/argocd-agent-rhel9@sha256:9c4775d30c4e7c250570b3f60accbe41368dee4ed04279a3a1b07681d1d95fdd
     - name: argocd_image_updater_image
-      image: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:4393a4a47b2e902ade4ac37161c590c835736df68542b15c75034e75915c2ec0
+      image: registry.redhat.io/openshift-gitops-1/argocd-image-updater-rhel9@sha256:b3f368b45f533b72798c60bc7404a6b1bf1a402f3a484bdf0f6be802e925e611


### PR DESCRIPTION
This PR updates the bundle files with the latest image shas for release-1.20 tag.

Automatically generated from `release-1.20` branch using GitHub Actions.