### PR TITLE
Update redis image to latest tag

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -105,7 +105,7 @@ externalImages:
     version: v4.19
   - name: "redis"
     image: registry.redhat.io/rhel9/redis-7
-    version: 9.6
+    version: latest
 
 # Konflux images are images that are built from the source in this repository
 konfluxImages:


### PR DESCRIPTION
Gitops uses hardcoded version of rhel9/redis which has shown some vulnerabilities. So we are updating redis image to latest tag.