### PR TITLE
chore(deps): bump image-updater from 1.2.2 to 1.3.0 for GitOps 1.22

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -88,8 +88,8 @@ sources:
     commit: 7bf329860e465e5138559fc1f6f79b7f7caba042
   - path: sources/argocd-image-updater
     url: https://github.com/argoproj-labs/argocd-image-updater.git
-    ref: v1.2.2
-    commit: 0e7ba4e51d2f8e64934f738db9f2b57274a401d3
+    ref: v1.3.0
+    commit: 098b544f1c7d6d1368e89c3f8d92415ede353916
 # External images pulled directly from Red Hat registry and are
 # required by the operator at runtime.
 # Bundle generation script will automatically fetch latest sha for each image 


### PR DESCRIPTION
https://github.com/argoproj-labs/argocd-image-updater/releases/tag/v1.3.0